### PR TITLE
Added support for unused entries structure xfs_dir2_data_unused

### DIFF
--- a/include/xal_odf.h
+++ b/include/xal_odf.h
@@ -375,4 +375,13 @@ struct xal_btree_lblock {
 	uint16_t btree_numrecs;	 /// Number of records in this block.
 	uint64_t btree_leftsib;
 	uint64_t btree_rightsib;
+
+	/* version 5 filesystem fields start here */
+	uint64_t btree_blkno;
+	uint64_t btree_lsn;
+	uuid_t btree_uuid;
+	uint64_t btree_owner;
+	uint32_t btree_crc;
+	uint32_t btree_pad;
 };
+


### PR DESCRIPTION
Added support for unused entries structure xfs_dir2_data_unused.
Without this if 
Added screenshot with and without unused entry support
![BeforeFix](https://github.com/user-attachments/assets/cb5b3f6c-3224-45f9-9c7c-097d
![after](https://github.com/user-attachments/assets/d5df29df-2c3a-47aa-b7e0-e36e282f2be9)
9aee0ea5)