### PR TITLE
Shared memory pools

### DIFF
--- a/docs/memory-pools.md
+++ b/docs/memory-pools.md
@@ -1,0 +1,70 @@
+# Pool Memory
+
+Inodes and extents are each stored in a separate pool (``struct xal_pool``),
+backed by a large over-committed ``mmap`` region.
+
+The pool reserves a virtual address range upfront sized for the maximum
+expected number of elements, but only commits physical pages in chunks as
+elements are claimed (via ``mprotect``). This keeps the array contiguous in
+memory — ``xal_inode_at(xal, idx)`` is a plain pointer offset — and means
+elements never move, so pool indices remain stable across all insertions.
+
+## Lazy growth (anonymous mode)
+
+By default, pools use private anonymous memory. The full virtual address range
+is reserved with ``PROT_NONE`` at open time; physical pages are committed in
+chunks of ``growby`` elements by calling ``mprotect(PROT_READ|PROT_WRITE)``
+whenever the pool runs low. This avoids upfront memory commitment while keeping
+the array at a single contiguous address.
+
+## Shared memory mode
+
+When ``xal_opts.shm_name`` is set, the two pools are backed by POSIX shared
+memory objects instead of anonymous memory. Because all internal
+cross-references within the pools use integer indices rather than raw
+pointers, the pool data is valid regardless of the virtual address at which
+it is mapped in each process. The names of the objects are
+derived from the base name by appending ``_inodes`` and ``_extents``
+respectively::
+
+   opts.shm_name = "/myapp_xal";
+   /* creates /myapp_xal_inodes and /myapp_xal_extents */
+
+In this mode the full reserved size is committed upfront via ``ftruncate()``
+and ``mmap(MAP_SHARED)``; there is no lazy growth. The objects persist in the
+shared memory filesystem (``/dev/shm`` on Linux) until explicitly removed.
+The process that opened xal with ``shm_name`` set is responsible for calling
+``shm_unlink()`` on both objects when they are no longer needed.
+``xal_close()`` will ``munmap`` the regions but will not unlink them.
+
+## Consumer processes: ``xal_from_pools()``
+
+A secondary process that needs read-only access to an already-indexed pool can
+attach to the shared memory objects directly, without opening the device or
+re-running ``xal_index()``. The typical pattern is:
+
+1. One process calls ``xal_open()`` with ``shm_name`` set and runs
+   ``xal_index()``. It then communicates the shared memory names and the
+   superblock (via ``xal_get_sb()``) to the other process, for example
+   through a Unix socket or another shared memory region.
+
+2. The other process maps both shared memory objects with ``shm_open()`` and
+   ``mmap(MAP_SHARED)``.
+
+3. It then calls ``xal_from_pools()`` with the received superblock and the
+   two mapped memory regions to obtain a read-only ``struct xal *``::
+
+      const struct xal_sb *sb = /* superblock communicated OOB */;
+      void *inodes_mem = /* mmap of /myapp_xal_inodes */;
+      void *extents_mem = /* mmap of /myapp_xal_extents */;
+      struct xal *view;
+
+      xal_from_pools(sb, NULL, inodes_mem, extents_mem, &view);
+      xal_walk(view, xal_get_root(view), my_callback, NULL);
+      xal_close(view); /* frees the struct; does NOT munmap or unlink */
+
+The resulting ``struct xal`` has ``shared_view`` set to ``true``.
+``xal_close()`` on a shared view frees only the ``struct xal`` allocation;
+the pool memory regions are left mapped and must be unmapped by the caller.
+The process that created the shared memory objects is responsible for
+``shm_unlink()``.

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -36,6 +36,7 @@
 
 #define XAL_INODE_NAME_MAXLEN 255
 #define XAL_PATH_MAXLEN 255
+#define XAL_POOL_IDX_NONE UINT32_MAX
 
 enum xal_backend {
 	XAL_BACKEND_XFS     = 1,
@@ -87,13 +88,13 @@ xal_extent_converted_pp(struct xal_extent_converted *extent);
 struct xal_inode;
 
 struct xal_dentries {
-	struct xal_inode *inodes; ///< Pointer to array of 'struct xal_inode'
-	uint32_t count;		  ///< Number of children; for directories
+	uint32_t inodes_idx; ///< Index of first child in xal->inodes pool
+	uint32_t count;      ///< Number of children; for directories
 };
 
 struct xal_extents {
-	struct xal_extent *extent; ///< Pointer to array of 'struct xal_extent'
-	uint32_t count;		   ///< Number of extents
+	uint32_t extent_idx; ///< Index of first extent in xal->extents pool
+	uint32_t count;      ///< Number of extents
 };
 
 union xal_inode_content {
@@ -109,11 +110,8 @@ struct xal_inode {
 	uint8_t namelen;		      ///< Length of the name; not counting nul-termination
 	char name[XAL_INODE_NAME_MAXLEN + 1]; ///< Name; not including nul-termination
 	uint8_t reserved[22];
-	struct xal_inode *parent;
+	uint32_t parent_idx;
 };
-
-int
-xal_inode_pp(struct xal_inode *inode);
 
 /**
  * XAL
@@ -125,6 +123,18 @@ xal_inode_pp(struct xal_inode *inode);
  * @struct xal
  */
 struct xal;
+
+struct xal_inode *
+xal_inode_at(struct xal *xal, uint32_t idx);
+
+struct xal_extent *
+xal_extent_at(struct xal *xal, uint32_t idx);
+
+uint32_t
+xal_inode_idx(struct xal *xal, struct xal_inode *inode);
+
+int
+xal_inode_pp(struct xal *xal, struct xal_inode *inode);
 
 /**
  * Returns the extent information in bytes.
@@ -287,7 +297,7 @@ uint64_t
 xal_fsbno_offset(struct xal *xal, uint64_t fsbno);
 
 int
-xal_inode_path_pp(struct xal_inode *inode);
+xal_inode_path_pp(struct xal *xal, struct xal_inode *inode);
 
 int
 build_inode_path(struct xal_inode *inode, char *buffer);

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -58,7 +58,7 @@ struct xal_opts {
 	enum xal_backend be;
 	enum xal_watchmode watch_mode;
 	enum xal_file_lookupmode file_lookupmode;
-	const char *shm_name; ///< If set, pool memory is backed by POSIX shared memory with this base name
+	const char *shm_name; ///< If set, pool memory is backed by POSIX shared memory with this base name, see @xal_from_pools() for sharing the pools across processes
 };
 
 struct xal_extent {
@@ -124,6 +124,22 @@ struct xal_inode {
  * @struct xal
  */
 struct xal;
+
+struct xal_sb {
+	uint32_t blocksize;    ///< Size of a block, in bytes
+	uint16_t sectsize;     ///< Size of a sector, in bytes
+	uint16_t inodesize;    ///< inode size, in bytes
+	uint16_t inopblock;    ///< inodes per block
+	uint8_t inopblog;      ///< log2 of inopblock
+	uint64_t icount;       ///< allocated inodes
+	uint64_t nallocated;   ///< Allocated inodes - sum of agi_count
+	uint64_t rootino;      ///< root inode number, in global-address format
+	uint32_t agblocks;     ///< Size of an allocation group, in blocks
+	uint8_t agblklog;      ///< log2 of 'agblocks' (rounded up)
+	uint32_t agcount;      ///< Number of allocation groups
+	uint32_t dirblocksize; ///< Size of a directory block, in bytes
+	uint32_t lba_blksze;   ///< LBA block size
+};
 
 struct xal_inode *
 xal_inode_at(struct xal *xal, uint32_t idx);
@@ -225,6 +241,27 @@ xal_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts);
 
 void
 xal_close(struct xal *xal);
+
+/**
+ * Construct a read-only xal from externally provided pool memory.
+ *
+ * Intended for processes that receive pool memory via POSIX shared memory from elsewhere.
+ * The caller is responsible for mapping the shared memory regions before calling this with the
+ * shm_name given in the xal_opts.
+ * The resulting xal can be closed with xal_close(), which will free the struct xal allocation but
+ * will not munmap or unlink the pool memory regions — that remains the caller's responsibility.
+ *
+ * @param sb           Superblock metadata
+ * @param mountpoint   Mountpoint of the file system
+ * @param inodes_mem   Pointer to the mapped inode pool memory; the root inode must be at index 0
+ * @param extents_mem  Pointer to the mapped extent pool memory
+ * @param out          Output pointer for the constructed xal
+ *
+ * @return On success, 0. On error, negative errno.
+ */
+int
+xal_from_pools(const struct xal_sb *sb, const char *mountpoint, void *inodes_mem,
+	void *extents_mem, struct xal **out);
 
 /**
  * Retrieve inodes from disk and decode the on-disk-format of the retrieved data

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -215,6 +215,9 @@ xal_is_dirty(struct xal *xal);
 int
 xal_get_seq_lock(struct xal *xal);
 
+const struct xal_sb *
+xal_get_sb(struct xal *xal);
+
 uint32_t
 xal_get_sb_blocksize(struct xal *xal);
 

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -58,6 +58,7 @@ struct xal_opts {
 	enum xal_backend be;
 	enum xal_watchmode watch_mode;
 	enum xal_file_lookupmode file_lookupmode;
+	const char *shm_name; ///< If set, pool memory is backed by POSIX shared memory with this base name
 };
 
 struct xal_extent {

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -1,3 +1,6 @@
+#ifndef LIBXAL_H
+#define LIBXAL_H
+
 /**
  * Public API for the XAL library
  *
@@ -358,3 +361,5 @@ xal_get_extents(struct xal *xal, char *path, struct xal_extents **extents);
  */
 int
 xal_get_dentries(struct xal *xal, char *path, struct xal_dentries **dentries);
+
+#endif /* LIBXAL_H */

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -340,9 +340,6 @@ xal_fsbno_offset(struct xal *xal, uint64_t fsbno);
 int
 xal_inode_path_pp(struct xal *xal, struct xal_inode *inode);
 
-int
-build_inode_path(struct xal_inode *inode, char *buffer);
-
 /**
  * Determine if the given inode is a directory
  *

--- a/include/xal.h
+++ b/include/xal.h
@@ -16,22 +16,6 @@ struct xal_backend_base {
 	void (*close)(struct xal *xal);
 };
 
-struct xal_sb {
-	uint32_t blocksize;    ///< Size of a block, in bytes
-	uint16_t sectsize;     ///< Size of a sector, in bytes
-	uint16_t inodesize;    ///< inode size, in bytes
-	uint16_t inopblock;    ///< inodes per block
-	uint8_t inopblog;      ///< log2 of inopblock
-	uint64_t icount;       ///< allocated inodes
-	uint64_t nallocated;   ///< Allocated inodes - sum of agi_count
-	uint64_t rootino;      ///< root inode number, in global-address format
-	uint32_t agblocks;     ///< Size of an allocation group, in blocks
-	uint8_t agblklog;      ///< log2 of 'agblocks' (rounded up)
-	uint32_t agcount;      ///< Number of allocation groups
-	uint32_t dirblocksize; ///< Size of a directory block, in bytes
-	uint32_t lba_blksze;   ///< LBA block size
-};
-
 /**
  * XAL
  * 
@@ -49,4 +33,5 @@ struct xal {
 	uint8_t be[XAL_BACKEND_SIZE];
 	atomic_bool dirty;       ///< Whether the file system has changed since last index
 	atomic_int seq_lock;     ///< An uneven number indicates the struct is being modified and is not safe to read
+	bool shared_view;        ///< If true, pool memory is owned externally; xal_close() will not unmap it
 };

--- a/include/xal.h
+++ b/include/xal.h
@@ -42,12 +42,11 @@ struct xal_sb {
  */
 struct xal {
 	struct xnvme_dev *dev;
-	struct xal_pool inodes;	 ///< Pool of inodes in host-native format
+	struct xal_pool inodes;  ///< Pool of inodes in host-native format
 	struct xal_pool extents; ///< Pool of extents in host-native format
-	struct xal_inode *root;	 ///< Root of the file-system
+	uint32_t root_idx;       ///< Index of the root inode in the inodes pool
 	struct xal_sb sb;
 	uint8_t be[XAL_BACKEND_SIZE];
 	atomic_bool dirty;       ///< Whether the file system has changed since last index
 	atomic_int seq_lock;     ///< An uneven number indicates the struct is being modified and is not safe to read
 };
-

--- a/include/xal.h
+++ b/include/xal.h
@@ -29,6 +29,7 @@ struct xal_sb {
 	uint8_t agblklog;      ///< log2 of 'agblocks' (rounded up)
 	uint32_t agcount;      ///< Number of allocation groups
 	uint32_t dirblocksize; ///< Size of a directory block, in bytes
+	uint32_t lba_blksze;   ///< LBA block size
 };
 
 /**

--- a/include/xal_be_fiemap.h
+++ b/include/xal_be_fiemap.h
@@ -8,5 +8,8 @@ struct xal_be_fiemap {
 };
 XAL_STATIC_ASSERT(sizeof(struct xal_be_fiemap) == XAL_BACKEND_SIZE, "Incorrect size");
 
+void
+xal_be_fiemap_close(struct xal *xal);
+
 int
 xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts);

--- a/include/xal_be_xfs.h
+++ b/include/xal_be_xfs.h
@@ -27,4 +27,4 @@ struct xal_be_xfs {
 XAL_STATIC_ASSERT(sizeof(struct xal_be_xfs) == XAL_BACKEND_SIZE, "Incorrect size");
 
 int
-xal_be_xfs_open(struct xnvme_dev *dev, struct xal **xal);
+xal_be_xfs_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts);

--- a/include/xal_pool.h
+++ b/include/xal_pool.h
@@ -1,3 +1,4 @@
+#include <stdint.h>
 
 /**
  * A pool of mmap backed memory for fixed-size elements.
@@ -33,25 +34,13 @@ int
 xal_pool_map(struct xal_pool *pool, size_t reserved, size_t allocated, size_t element_size);
 
 /**
- * Claims the current inode-offset
- *
- * This is utilized when decoding device-entries and the amount is not known ahead of time,
- * thus, the current position is written to 'inode', subsequent calls to
- */
-void
-xal_pool_current_inode(struct xal_pool *pool, struct xal_inode **inode);
-
-void
-xal_pool_current_extent(struct xal_pool *pool, struct xal_extent **extent);
-
-/**
  *
  */
 int
-xal_pool_claim_extents(struct xal_pool *pool, size_t count, struct xal_extent **extents);
+xal_pool_claim_extents(struct xal_pool *pool, size_t count, uint32_t *idx);
 
 int
-xal_pool_claim_inodes(struct xal_pool *pool, size_t count, struct xal_inode **inodes);
+xal_pool_claim_inodes(struct xal_pool *pool, size_t count, uint32_t *idx);
 
 int
 xal_pool_clear(struct xal_pool *pool);

--- a/include/xal_pool.h
+++ b/include/xal_pool.h
@@ -29,9 +29,15 @@ xal_pool_unmap(struct xal_pool *pool);
  * See the xal_pool_claim() helper, which provides arrays of allocated memory usable for
  * inode-storage. The number of allocated inodes are grown, when claimed, until the reserved space
  * is exhausted.
+ *
+ * If shm_name is NULL, uses private anonymous memory with lazy mprotect growth.
+ * If shm_name is non-NULL, backs the pool with a POSIX shared memory object of that name.
+ * In the shm case the full reserved size is committed upfront and the caller is responsible
+ * for shm_unlink() when the shm is no longer needed.
  */
 int
-xal_pool_map(struct xal_pool *pool, size_t reserved, size_t allocated, size_t element_size);
+xal_pool_map(struct xal_pool *pool, size_t reserved, size_t allocated, size_t element_size,
+             const char *shm_name);
 
 /**
  *

--- a/src/cli.c
+++ b/src/cli.c
@@ -84,7 +84,7 @@ parse_args(int argc, char *argv[], struct xal_cli_args *args)
  * Produces output on stdout similar to the output produced by running "find /mount/point"
  */
 int
-node_inspector_find(struct xal *XAL_UNUSED(xal), struct xal_inode *inode, void *cb_args,
+node_inspector_find(struct xal *xal, struct xal_inode *inode, void *cb_args,
 		    int XAL_UNUSED(level))
 {
 	struct xal_nodeinspector_args *args = cb_args;
@@ -99,11 +99,11 @@ node_inspector_find(struct xal *XAL_UNUSED(xal), struct xal_inode *inode, void *
 	}
 
 	printf("%s", args->cli_args->dev_uri);
-	if ((inode->parent) &&
+	if ((inode->parent_idx != XAL_POOL_IDX_NONE) &&
 	    (args->cli_args->dev_uri[strlen(args->cli_args->dev_uri) - 1] == '/')) {
 		printf("/");
 	}
-	xal_inode_path_pp(inode);
+	xal_inode_path_pp(xal, inode);
 	printf("\n");
 	return 0;
 }
@@ -114,7 +114,7 @@ pp_inode_extents(struct xal *xal, struct xal_inode *inode)
 	uint32_t blocksize = xal_get_sb_blocksize(xal);
 
 	for (uint32_t i = 0; i < inode->content.extents.count; ++i) {
-		struct xal_extent *extent = &inode->content.extents.extent[i];
+		struct xal_extent *extent = xal_extent_at(xal, inode->content.extents.extent_idx + i);
 		size_t fofz_begin, fofz_end, bofz_begin, bofz_end;
 
 		fofz_begin = (extent->start_offset * blocksize) / 512;
@@ -145,12 +145,12 @@ node_inspector_bmap(struct xal *xal, struct xal_inode *inode, void *cb_args, int
 	}
 
 	printf("'%s", args->cli_args->dev_uri);
-	if ((inode->parent) &&
+	if ((inode->parent_idx != XAL_POOL_IDX_NONE) &&
 	    (args->cli_args->dev_uri[strlen(args->cli_args->dev_uri) - 1] == '/')) {
 		printf("/");
 	}
 
-	xal_inode_path_pp(inode);
+	xal_inode_path_pp(xal, inode);
 	printf("':");
 
 	if (!inode->content.extents.count) {

--- a/src/pp.c
+++ b/src/pp.c
@@ -160,7 +160,7 @@ xal_odf_dinode_format_str(int val)
 }
 
 int
-xal_inode_pp(struct xal_inode *inode)
+xal_inode_pp(struct xal *xal, struct xal_inode *inode)
 {
 	int wrtn = 0;
 
@@ -177,12 +177,12 @@ xal_inode_pp(struct xal_inode *inode)
 
 	switch (inode->ftype) {
 	case XAL_ODF_DIR3_FT_DIR:
+		struct xal_inode *children = xal_inode_at(xal, inode->content.dentries.inodes_idx);
+
 		wrtn += printf("  dentries.count: %u\n", inode->content.dentries.count);
 
 		for (uint8_t i = 0; i < inode->content.dentries.count; ++i) {
-			struct xal_inode *children = inode->content.dentries.inodes;
-
-			xal_inode_pp(&children[i]);
+			xal_inode_pp(xal, &children[i]);
 		}
 
 		break;

--- a/src/xal.c
+++ b/src/xal.c
@@ -103,8 +103,10 @@ int
 xal_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts)
 {
 	const struct xnvme_ident *ident;
+	const struct xnvme_spec_idfy_ns *ns;
 	struct xal_opts opts_default = {0};
 	char mountpoint[XAL_PATH_MAXLEN + 1] = {0};
+	uint8_t fidx;
 	int err;
 
 	if (!dev) {
@@ -166,6 +168,20 @@ xal_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts)
 	}
 
 	(*xal)->dev = dev;
+
+	ns = xnvme_dev_get_ns(dev);
+	if (!ns) {
+		err = -errno;
+		XAL_DEBUG("FAILED: xnvme_dev_get_ns(); err(%d)", err);
+		return err;
+	}
+
+	fidx = ns->flbas.format;
+	if (ns->nlbaf > 16) {
+		fidx += ns->flbas.format_msb << 4;
+	}
+
+	(*xal)->sb.lba_blksze = 1U << ns->lbaf[fidx].ds;
 
 	return 0;
 }
@@ -297,28 +313,12 @@ xal_extent_in_bytes(struct xal *xal, const struct xal_extent *extent, struct xal
 int
 xal_extent_in_lba(struct xal *xal, const struct xal_extent *extent, struct xal_extent_converted *output)
 {
-	const struct xnvme_spec_idfy_ns *ns;
-	uint8_t fidx;
-	uint lba_blksze;
+	uint32_t lba_blksze = xal->sb.lba_blksze;
 
 	if (!extent) {
 		XAL_DEBUG("FAILED: no extent given");
 		return -EINVAL;
 	}
-
-	ns = xnvme_dev_get_ns(xal->dev);
-	if (!ns) {
-		XAL_DEBUG("FAILED: xnvme_dev_get_ns(); errno(%d)", errno);
-		return -errno;
-	}
-
-	fidx = ns->flbas.format;
-	if (ns->nlbaf > 16) {
-		fidx += ns->flbas.format_msb << 4;
-	}
-
-	lba_blksze = 1U << ns->lbaf[fidx].ds;
-	XAL_DEBUG("INFO: Found lba block size %d", lba_blksze);
 
 	output->start_offset = extent->start_offset * xal->sb.blocksize / lba_blksze;
 	output->size = extent->nblocks * xal->sb.blocksize / lba_blksze;

--- a/src/xal.c
+++ b/src/xal.c
@@ -68,6 +68,43 @@ xal_inode_idx(struct xal *xal, struct xal_inode *inode)
 	return (uint32_t)(inode - (struct xal_inode *)xal->inodes.memory);
 }
 
+int
+xal_from_pools(const struct xal_sb *sb, const char *mountpoint, void *inodes_mem,
+	void *extents_mem, struct xal **out)
+{
+	struct xal *xal;
+
+	xal = calloc(1, sizeof(*xal));
+	if (!xal) {
+		return -ENOMEM;
+	}
+
+	xal->sb = *sb;
+	xal->root_idx = 0;
+	xal->shared_view = true;
+
+	if (mountpoint) {
+		struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
+		be->base.type = XAL_BACKEND_FIEMAP;
+		be->base.close = xal_be_fiemap_close;
+		be->mountpoint = strdup(mountpoint);
+		if (!be->mountpoint) {
+			free(xal);
+			return -ENOMEM;
+		}
+	}
+
+	xal->inodes.memory = inodes_mem;
+	xal->inodes.element_size = sizeof(struct xal_inode);
+
+	xal->extents.memory = extents_mem;
+	xal->extents.element_size = sizeof(struct xal_extent);
+
+	*out = xal;
+
+	return 0;
+}
+
 void
 xal_close(struct xal *xal)
 {
@@ -77,11 +114,22 @@ xal_close(struct xal *xal)
 		return;
 	}
 
+	if (xal->shared_view) {
+		be = (struct xal_backend_base *)&xal->be;
+		if (be->close) {
+			be->close(xal);
+		}
+		free(xal);
+		return;
+	}
+
 	xal_pool_unmap(&xal->inodes);
 	xal_pool_unmap(&xal->extents);
 
 	be = (struct xal_backend_base *)&xal->be;
-	be->close(xal);
+	if (be->close) {
+		be->close(xal);
+	}
 
 	free(xal);
 }
@@ -208,6 +256,10 @@ int
 xal_index(struct xal *xal)
 {
 	struct xal_backend_base *be = (struct xal_backend_base *)&xal->be;
+
+	if (xal->shared_view) {
+		return -EINVAL;
+	}
 
 	return be->index(xal);
 }

--- a/src/xal.c
+++ b/src/xal.c
@@ -50,6 +50,24 @@ xal_fsbno_offset(struct xal *xal, uint64_t fsbno)
 	}
 }
 
+struct xal_inode *
+xal_inode_at(struct xal *xal, uint32_t idx)
+{
+	return (struct xal_inode *)xal->inodes.memory + idx;
+}
+
+struct xal_extent *
+xal_extent_at(struct xal *xal, uint32_t idx)
+{
+	return (struct xal_extent *)xal->extents.memory + idx;
+}
+
+uint32_t
+xal_inode_idx(struct xal *xal, struct xal_inode *inode)
+{
+	return (uint32_t)(inode - (struct xal_inode *)xal->inodes.memory);
+}
+
 void
 xal_close(struct xal *xal)
 {
@@ -213,7 +231,7 @@ _walk(struct xal *xal, struct xal_inode *inode, xal_walk_cb cb_func, void *cb_da
 
 	switch (inode->ftype) {
 	case XAL_ODF_DIR3_FT_DIR: {
-		struct xal_inode *inodes = inode->content.dentries.inodes;
+		struct xal_inode *inodes = xal_inode_at(xal, inode->content.dentries.inodes_idx);
 
 		for (uint32_t i = 0; i < inode->content.dentries.count; ++i) {
 			err = _walk(xal, &inodes[i], cb_func, cb_data, depth + 1);
@@ -243,7 +261,7 @@ xal_walk(struct xal *xal, struct xal_inode *inode, xal_walk_cb cb_func, void *cb
 struct xal_inode *
 xal_get_root(struct xal *xal)
 {
-	return xal->root;
+	return xal_inode_at(xal, xal->root_idx);
 }
 
 bool
@@ -265,18 +283,18 @@ xal_get_sb_blocksize(struct xal *xal)
 }
 
 int
-xal_inode_path_pp(struct xal_inode *inode)
+xal_inode_path_pp(struct xal *xal, struct xal_inode *inode)
 {
 	int wrtn = 0;
 
 	if (!inode) {
 		return wrtn;
 	}
-	if (!inode->parent) {
+	if (inode->parent_idx == XAL_POOL_IDX_NONE) {
 		return wrtn;
 	}
 
-	wrtn += xal_inode_path_pp(inode->parent);
+	wrtn += xal_inode_path_pp(xal, xal_inode_at(xal, inode->parent_idx));
 	wrtn += printf("/%.*s", inode->namelen, inode->name);
 
 	return wrtn;

--- a/src/xal.c
+++ b/src/xal.c
@@ -155,7 +155,7 @@ xal_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts)
 
 	switch (opts->be) {
 		case XAL_BACKEND_XFS:
-			err = xal_be_xfs_open(dev, xal);
+			err = xal_be_xfs_open(dev, xal, opts);
 			if (err) {
 				XAL_DEBUG("FAILED: xal_be_xfs_open(); err(%d)", err);
 				return err;

--- a/src/xal.c
+++ b/src/xal.c
@@ -328,6 +328,12 @@ xal_get_seq_lock(struct xal *xal)
 	return atomic_load(&xal->seq_lock);
 }
 
+const struct xal_sb *
+xal_get_sb(struct xal *xal)
+{
+	return &xal->sb;
+}
+
 uint32_t
 xal_get_sb_blocksize(struct xal *xal)
 {

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -129,6 +129,8 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 	struct xal *cand;
 	struct stat sb;
 	struct xal_be_fiemap *be;
+	char shm_name[XAL_PATH_MAXLEN + 9];
+	const char *shm;
 	int nallocated, err;
 
 	if (!mountpoint) {
@@ -191,15 +193,29 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 	cand->sb.blocksize = sb.st_blksize;
 	cand->sb.rootino = sb.st_ino;
 
-	err =
-	    xal_pool_map(&cand->inodes, 40000000UL, nallocated, sizeof(struct xal_inode));
+	if (opts->shm_name && strlen(opts->shm_name) > XAL_PATH_MAXLEN) {
+		XAL_DEBUG("FAILED: shm_name too long");
+		err = -EINVAL;
+		goto failed;
+	}
+
+	shm = NULL;
+	if (opts->shm_name) {
+		snprintf(shm_name, sizeof(shm_name), "%s_inodes", opts->shm_name);
+		shm = shm_name;
+	}
+	err = xal_pool_map(&cand->inodes, 40000000UL, nallocated, sizeof(struct xal_inode), shm);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_map(inodes); err(%d)", err);
 		goto failed;
 	}
 
-	err =
-	    xal_pool_map(&cand->extents, 40000000UL, nallocated, sizeof(struct xal_extent));
+	shm = NULL;
+	if (opts->shm_name) {
+		snprintf(shm_name, sizeof(shm_name), "%s_extents", opts->shm_name);
+		shm = shm_name;
+	}
+	err = xal_pool_map(&cand->extents, 40000000UL, nallocated, sizeof(struct xal_extent), shm);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_map(extents); err(%d)", err);
 		goto failed;

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -142,6 +142,8 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 		return -errno;
 	}
 
+	cand->root_idx = XAL_POOL_IDX_NONE;
+
 	be = (struct xal_be_fiemap *)&cand->be;
 
 	be->base.type = XAL_BACKEND_FIEMAP;
@@ -278,7 +280,7 @@ xal_be_fiemap_process_inode_dir(struct xal *xal, char *path, struct xal_inode *i
 
 	qsort(entries, n_entries, sizeof(*entries), compare_dirent);
 
-	err = xal_pool_claim_inodes(&xal->inodes, n_entries, &inode->content.dentries.inodes);
+	err = xal_pool_claim_inodes(&xal->inodes, n_entries, &inode->content.dentries.inodes_idx);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_claim_inodes(); err(%d)", err);
 		goto failed;
@@ -289,14 +291,14 @@ xal_be_fiemap_process_inode_dir(struct xal *xal, char *path, struct xal_inode *i
 	for (size_t i = 0; i < n_entries; i++) {
 		entry = entries[i];
 
-		struct xal_inode *dentry = &inode->content.dentries.inodes[inode->content.dentries.count];
+		struct xal_inode *dentry = xal_inode_at(xal, inode->content.dentries.inodes_idx + inode->content.dentries.count);
 
 		char dentry_path[strlen(path) + 1 + strlen(entry->d_name) + 1];
 		snprintf(dentry_path, sizeof(dentry_path), "%s/%s", path, entry->d_name);
 
 		strcpy(dentry->name, dentry_path);
 		dentry->namelen = strlen(dentry->name);
-		dentry->parent = inode;
+		dentry->parent_idx = xal_inode_idx(xal, inode);
 
 		inode->content.dentries.count += 1;
 
@@ -414,7 +416,7 @@ xal_be_fiemap_process_inode_file(struct xal *xal, char *path, struct xal_inode *
 	if (fiemap->fm_mapped_extents > 0) {
 		struct xal_extents *extents;
 
-		err = xal_pool_claim_extents(&xal->extents, fiemap->fm_mapped_extents, &inode->content.extents.extent);
+		err = xal_pool_claim_extents(&xal->extents, fiemap->fm_mapped_extents, &inode->content.extents.extent_idx);
 		if (err) {
 			XAL_DEBUG("FAILED: xal_pool_claim_extents(); err(%d)", err);
 			goto failed;
@@ -424,7 +426,7 @@ xal_be_fiemap_process_inode_file(struct xal *xal, char *path, struct xal_inode *
 		extents->count = fiemap->fm_mapped_extents;
 
 		for (uint32_t i = 0; i < extents->count; i++) {
-			struct xal_extent *extent = &extents->extent[i];
+			struct xal_extent *extent = xal_extent_at(xal, extents->extent_idx + i);
 
 			extent->start_offset = fiemap->fm_extents[i].fe_logical / xal->sb.blocksize;
 			extent->start_block  = fiemap->fm_extents[i].fe_physical / xal->sb.blocksize;
@@ -520,6 +522,7 @@ int
 xal_be_fiemap_index(struct xal *xal)
 {
 	struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
+	struct xal_inode *root;
 	int err;
 
 	if (!strlen(be->mountpoint)) {
@@ -541,19 +544,21 @@ xal_be_fiemap_index(struct xal *xal)
 		}
 	}
 
-	err = xal_pool_claim_inodes(&xal->inodes, 1, &xal->root);
+	err = xal_pool_claim_inodes(&xal->inodes, 1, &xal->root_idx);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_claim_inodes(); err(%d)", err);
 		goto exit;
 	}
 
-	xal->root->ino = xal->sb.rootino;
-	xal->root->ftype = XAL_ODF_DIR3_FT_DIR;
-	xal->root->namelen = 0;
-	xal->root->content.extents.count = 0;
-	xal->root->content.dentries.count = 0;
+	root = xal_inode_at(xal, xal->root_idx);
+	root->ino = xal->sb.rootino;
+	root->ftype = XAL_ODF_DIR3_FT_DIR;
+	root->namelen = 0;
+	root->parent_idx = XAL_POOL_IDX_NONE;
+	root->content.extents.count = 0;
+	root->content.dentries.count = 0;
 
-	err = process_ino_fiemap(xal, be->mountpoint, xal->root);
+	err = process_ino_fiemap(xal, be->mountpoint, root);
 	if (err) {
 		XAL_DEBUG("FAILED: process_ino_fiemap(); err(%d)", err);
 		goto exit;
@@ -584,8 +589,9 @@ compare_name_to_inode(const void *key, const void *elem)
 }
 
 static int
-search_by_traversal(struct xal_be_fiemap *be, struct xal_inode *root, char *path, struct xal_inode **inode)
+search_by_traversal(struct xal *xal, struct xal_inode *root, char *path, struct xal_inode **inode)
 {
+	struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
 	struct xal_inode *search, *found = NULL;
 	char *search_begin, *search_end;
 	size_t mountpoint_len;
@@ -621,7 +627,7 @@ search_by_traversal(struct xal_be_fiemap *be, struct xal_inode *root, char *path
 		memcpy(component, search_begin, search_len);
 		component[search_len] = '\0';
 
-		child = bsearch(component, search->content.dentries.inodes,
+		child = bsearch(component, xal_inode_at(xal, search->content.dentries.inodes_idx),
 				search->content.dentries.count, sizeof(struct xal_inode), compare_name_to_inode);
 
 		if (!child) {
@@ -682,7 +688,7 @@ xal_get_inode(struct xal *xal, char *path, struct xal_inode **inode)
 		*inode = kh_val(map, iter);
 
 	} else {
-		err = search_by_traversal(be, xal->root, path, inode);
+		err = search_by_traversal(xal, xal_inode_at(xal, xal->root_idx), path, inode);
 		if (err) {
 			XAL_DEBUG("FAILED: search_by_traversal(%s); err(%d)", path, err);
 			return err;

--- a/src/xal_be_fiemap_inotify.c
+++ b/src/xal_be_fiemap_inotify.c
@@ -134,20 +134,21 @@ xal_be_fiemap_inotify_add_watcher(struct xal_inotify *inotify, char *path, struc
 }
 
 static int
-_inode_path(struct xal_be_fiemap *be, struct xal_inode *inode, char *path, int *idx)
+_inode_path(struct xal *xal, struct xal_inode *inode, char *path, int *idx)
 {
+	struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
 	int wrtn, err;
 
 	if (!inode) {
 		return -1;
 	}
-	if (!inode->parent) {
+	if (inode->parent_idx == XAL_POOL_IDX_NONE) {
 		wrtn = snprintf(path + *idx, XAL_PATH_MAXLEN - *idx, "%s", be->mountpoint);
 		*idx += wrtn;
 		return 0;
 	}
 
-	err = _inode_path(be, inode->parent, path, idx);
+	err = _inode_path(xal, xal_inode_at(xal, inode->parent_idx), path, idx);
 	if (err) {
 		XAL_DEBUG("FAILED: _inode_path()");
 		return err;
@@ -165,10 +166,9 @@ _inode_path(struct xal_be_fiemap *be, struct xal_inode *inode, char *path, int *
 static int
 get_inode_path(struct xal *xal, struct xal_inode *inode, char *path)
 {
-	struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
 	int err, idx = 0;
 
-	err = _inode_path(be, inode, path, &idx);
+	err = _inode_path(xal, inode, path, &idx);
 	if (err) {
 		XAL_DEBUG("FAILED: _inode_path()");
 		return err;
@@ -275,7 +275,7 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 				atomic_fetch_add(&xal->seq_lock, 1);
 
 				for (uint32_t j = 0; j < dir_inode->content.dentries.count; ++j) {
-					struct xal_inode *child = &dir_inode->content.dentries.inodes[j];
+					struct xal_inode *child = xal_inode_at(xal, dir_inode->content.dentries.inodes_idx + j);
 
 					if (strcmp(child->name, event->name) == 0) {
 						inode = child;
@@ -296,7 +296,7 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 				}
 
 				XAL_DEBUG("INFO: reprocessing inode:");
-				XAL_DEBUG_FCALL(xal_inode_pp(inode));
+				XAL_DEBUG_FCALL(xal_inode_pp(xal, inode));
 
 				err = xal_be_fiemap_process_inode_file(xal, path, inode);
 				if (err) {
@@ -305,7 +305,7 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 				}
 
 				XAL_DEBUG("INFO: finished reprocessing inode:");
-				XAL_DEBUG_FCALL(xal_inode_pp(inode));
+				XAL_DEBUG_FCALL(xal_inode_pp(xal, inode));
 
 				atomic_fetch_add(&xal->seq_lock, 1);
 
@@ -404,7 +404,7 @@ xal_watch_filesystem(struct xal *xal)
 		return 0;
 	}
 
-	if (!xal->root) {
+	if (xal->root_idx == XAL_POOL_IDX_NONE) {
 		XAL_DEBUG("FAILED: Missing call to xal_index()");
 		return -EINVAL;
 	}

--- a/src/xal_be_xfs.c
+++ b/src/xal_be_xfs.c
@@ -650,6 +650,8 @@ retrieve_and_decode_primary_superblock(struct xnvme_dev *dev, void *buf, struct 
 		return -errno;
 	}
 
+	cand->root_idx = XAL_POOL_IDX_NONE;
+
 	be = (struct xal_be_xfs *)&cand->be;
 
 	agcount = be32toh(psb->agcount);
@@ -849,6 +851,7 @@ btree_lblock_decode_leaf_records(struct xal *xal, void *buf, struct xal_inode *s
 			for (uint64_t ofz = 64; ofz < xal->sb.dirblocksize;) {
 				uint8_t *dentry_cursor = dblock + ofz;
 				struct xal_inode dentry = {0};
+				uint32_t slot;
 
 				ofz += decode_dentry(dentry_cursor, &dentry);
 
@@ -873,17 +876,15 @@ btree_lblock_decode_leaf_records(struct xal *xal, void *buf, struct xal_inode *s
 					continue;
 				}
 
-				dentry.parent = self;
-				self->content.dentries.inodes[self->content.dentries.count] =
-				    dentry;
-
-				self->content.dentries.count += 1;
-
-				err = xal_pool_claim_inodes(&xal->inodes, 1, NULL);
+				err = xal_pool_claim_inodes(&xal->inodes, 1, &slot);
 				if (err) {
 					XAL_DEBUG("FAILED: xal_pool_claim_inodes(...)");
 					return err;
 				}
+
+				dentry.parent_idx = xal_inode_idx(xal, self);
+				*xal_inode_at(xal, slot) = dentry;
+				self->content.dentries.count += 1;
 			}
 		}
 	}
@@ -975,7 +976,7 @@ process_dinode_dir_btree_root(struct xal *xal, struct xal_odf_dinode *dinode,
 		XAL_DEBUG("INFO: dentries.count(%" PRIu32 ")", self->content.dentries.count);
 		return -EINVAL;
 	}
-	xal_pool_current_inode(&xal->inodes, &self->content.dentries.inodes);
+	self->content.dentries.inodes_idx = xal->inodes.free;
 
 	XAL_DEBUG("=### Processing: File-System Block Pointers ###=");
 	XAL_DEBUG("INFO: pos.numrecs(%" PRIu16 ")", pos.numrecs);
@@ -992,7 +993,7 @@ process_dinode_dir_btree_root(struct xal *xal, struct xal_odf_dinode *dinode,
 	XAL_DEBUG("=### Processing: inodes constructed when chasing File-System Block Pointers")
 	XAL_DEBUG("INFO: dentries.count(%" PRIu32 ")", self->content.dentries.count);
 	for (uint32_t i = 0; i < self->content.dentries.count; ++i) {
-		struct xal_inode *inode = &self->content.dentries.inodes[i];
+		struct xal_inode *inode = xal_inode_at(xal, self->content.dentries.inodes_idx + i);
 
 		XAL_DEBUG("INFO: inode->name(%.*s)", inode->namelen, inode->name);
 		err = process_ino(xal, inode->ino, inode);
@@ -1014,6 +1015,7 @@ process_file_btree_leaf(struct xal *xal, uint64_t fsbno, struct xal_inode *self)
 	uint64_t ofz = xal_fsbno_offset(xal, fsbno);
 	struct xal_odf_btree_lfmt leaf = {0};
 	struct xal_extent *extents;
+	uint32_t extent_start;
 	int err;
 
 	XAL_DEBUG("ENTER: File Extents -- B+Tree -- Leaf Node");
@@ -1049,12 +1051,12 @@ process_file_btree_leaf(struct xal *xal, uint64_t fsbno, struct xal_inode *self)
 	XAL_DEBUG("INFO: rightsib(0x%016" PRIx64 " @ %" PRIu64 ")", leaf.siblings.right,
 		  xal_fsbno_offset(xal, leaf.siblings.right));
 
-	extents = &self->content.extents.extent[self->content.extents.count];
-	err = xal_pool_claim_extents(&xal->extents, leaf.pos.numrecs, NULL);
+	err = xal_pool_claim_extents(&xal->extents, leaf.pos.numrecs, &extent_start);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_claim_extents(); err(%d)", err);
 		return err;
 	}
+	extents = xal_extent_at(xal, extent_start);
 	self->content.extents.count += leaf.pos.numrecs;
 
 	for (uint16_t rec = 0; rec < leaf.pos.numrecs; ++rec) {
@@ -1201,7 +1203,7 @@ process_dinode_file_btree_root(struct xal *xal, struct xal_odf_dinode *dinode,
 			  self->content.extents.count);
 		return -EINVAL;
 	}
-	xal_pool_current_extent(&xal->extents, &self->content.extents.extent);
+	self->content.extents.extent_idx = xal->extents.free;
 
 	XAL_DEBUG("#### Processing Pointers ###");
 	for (uint16_t rec = 0; rec < numrecs; ++rec) {
@@ -1251,7 +1253,7 @@ process_dinode_dir_local(struct xal *xal, struct xal_odf_dinode *dinode, struct 
 
 	self->content.dentries.count = count;
 
-	err = xal_pool_claim_inodes(&xal->inodes, count, &self->content.dentries.inodes);
+	err = xal_pool_claim_inodes(&xal->inodes, count, &self->content.dentries.inodes_idx);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_claim_inodes(); err(%d)", err);
 		return err;
@@ -1259,7 +1261,7 @@ process_dinode_dir_local(struct xal *xal, struct xal_odf_dinode *dinode, struct 
 
 	/** DECODE: namelen[1], offset[2], name[namelen], ftype[1], ino[4] | ino[8] */
 	for (int i = 0; i < count; ++i) {
-		struct xal_inode *dentry = &self->content.dentries.inodes[i];
+		struct xal_inode *dentry = xal_inode_at(xal, self->content.dentries.inodes_idx + i);
 
 		dentry->namelen = *cursor;
 		cursor += 1 + 2; ///< Advance past 'namelen' and 'offset[2]'
@@ -1281,9 +1283,9 @@ process_dinode_dir_local(struct xal *xal, struct xal_odf_dinode *dinode, struct 
 	}
 
 	for (int i = 0; i < count; ++i) {
-		struct xal_inode *dentry = &self->content.dentries.inodes[i];
+		struct xal_inode *dentry = xal_inode_at(xal, self->content.dentries.inodes_idx + i);
 
-		dentry->parent = self;
+		dentry->parent_idx = xal_inode_idx(xal, self);
 		err = process_ino(xal, dentry->ino, dentry);
 		if (err) {
 			XAL_DEBUG("FAILED: process_ino()");
@@ -1315,14 +1317,14 @@ process_dinode_file_extents(struct xal *xal, struct xal_odf_dinode *dinode, stru
 	XAL_DEBUG("INFO: name(%.*s)", self->namelen, self->name);
 	XAL_DEBUG("INFO: nextents(%" PRIu64 ")", nextents);
 
-	err = xal_pool_claim_extents(&xal->extents, nextents, &self->content.extents.extent);
+	err = xal_pool_claim_extents(&xal->extents, nextents, &self->content.extents.extent_idx);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_claim()...");
 		return err;
 	}
 	self->content.extents.count = nextents;
 
-	extents = self->content.extents.extent;
+	extents = xal_extent_at(xal, self->content.extents.extent_idx);
 	for (uint64_t rec = 0; rec < nextents; ++rec) {
 		XAL_DEBUG("INFO: i(%" PRIu64 ")", rec);
 
@@ -1407,7 +1409,8 @@ process_dinode_dir_extents_dblock(struct xal *xal, uint64_t fsbno, struct xal_in
 
 	for (uint64_t ofz = 64; ofz < xal->sb.dirblocksize;) {
 		uint8_t *dentry_cursor = dblock + ofz;
-		struct xal_inode dentry = {.parent = self};
+		struct xal_inode dentry = {0};
+		uint32_t slot;
 
 		ofz += decode_dentry(dentry_cursor, &dentry);
 
@@ -1431,13 +1434,14 @@ process_dinode_dir_extents_dblock(struct xal *xal, uint64_t fsbno, struct xal_in
 			continue;
 		}
 
-		err = xal_pool_claim_inodes(&xal->inodes, 1, NULL);
+		err = xal_pool_claim_inodes(&xal->inodes, 1, &slot);
 		if (err) {
 			XAL_DEBUG("FAILED: xal_pool_claim_inodes(...)");
 			return err;
 		}
 
-		self->content.dentries.inodes[self->content.dentries.count] = dentry;
+		dentry.parent_idx = xal_inode_idx(xal, self);
+		*xal_inode_at(xal, slot) = dentry;
 		self->content.dentries.count += 1;
 	}
 
@@ -1502,7 +1506,7 @@ process_dinode_dir_extents(struct xal *xal, struct xal_odf_dinode *dinode, struc
 	XAL_DEBUG("INFO: fsblk_per_dblk(%" PRIu32 ")", fsblk_per_dblk);
 	XAL_DEBUG("INFO:         nbytes(%" PRIu64 ")", nbytes);
 
-	xal_pool_current_inode(&xal->inodes, &self->content.dentries.inodes);
+	self->content.dentries.inodes_idx = xal->inodes.free;
 
 	/**
 	 * Decode the extents and process each block
@@ -1537,7 +1541,7 @@ process_dinode_dir_extents(struct xal *xal, struct xal_odf_dinode *dinode, struc
 
 	XAL_DEBUG("=### Processing: inodes constructed when decoding dir(FMT_EXTENTS)")
 	for (uint32_t i = 0; i < self->content.dentries.count; ++i) {
-		struct xal_inode *inode = &self->content.dentries.inodes[i];
+		struct xal_inode *inode = xal_inode_at(xal, self->content.dentries.inodes_idx + i);
 
 		err = process_ino(xal, inode->ino, inode);
 		if (err) {
@@ -1591,7 +1595,7 @@ process_ino(struct xal *xal, uint64_t ino, struct xal_inode *self)
 	case XAL_DINODE_FMT_BTREE:
 		switch (self->ftype) {
 		case XAL_ODF_DIR3_FT_DIR:
-			xal_pool_current_inode(&xal->inodes, &self->content.dentries.inodes);
+			self->content.dentries.inodes_idx = xal->inodes.free;
 
 			err = process_dinode_dir_btree_root(xal, dinode, self);
 			if (err) {
@@ -1672,6 +1676,7 @@ process_ino(struct xal *xal, uint64_t ino, struct xal_inode *self)
 int
 xal_be_xfs_index(struct xal *xal)
 {
+	struct xal_inode *root;
 	struct xal_be_xfs *be = (struct xal_be_xfs *)&xal->be;
 	int err;
 
@@ -1682,18 +1687,20 @@ xal_be_xfs_index(struct xal *xal)
 	xal_pool_clear(&xal->inodes);
 	xal_pool_clear(&xal->extents);
 
-	err = xal_pool_claim_inodes(&xal->inodes, 1, &xal->root);
+	err = xal_pool_claim_inodes(&xal->inodes, 1, &xal->root_idx);
 	if (err) {
 		return err;
 	}
 
-	xal->root->ino = xal->sb.rootino;
-	xal->root->ftype = XAL_ODF_DIR3_FT_DIR;
-	xal->root->namelen = 0;
-	xal->root->content.extents.count = 0;
-	xal->root->content.dentries.count = 0;
+	root = xal_inode_at(xal, xal->root_idx);
+	root->ino = xal->sb.rootino;
+	root->ftype = XAL_ODF_DIR3_FT_DIR;
+	root->namelen = 0;
+	root->parent_idx = XAL_POOL_IDX_NONE;
+	root->content.extents.count = 0;
+	root->content.dentries.count = 0;
 
-	err = process_ino(xal, xal->root->ino, xal->root);
+	err = process_ino(xal, root->ino, root);
 	if (err) {
 		XAL_DEBUG("FAILED: process_ino(); err(%d)", err);
 		return err;

--- a/src/xal_be_xfs.c
+++ b/src/xal_be_xfs.c
@@ -681,10 +681,12 @@ retrieve_and_decode_primary_superblock(struct xnvme_dev *dev, void *buf, struct 
 }
 
 int
-xal_be_xfs_open(struct xnvme_dev *dev, struct xal **xal)
+xal_be_xfs_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts)
 {
 	struct xal *cand = NULL;
 	struct xal_be_xfs *be;
+	char shm_name[XAL_PATH_MAXLEN + 9];
+	const char *shm;
 	void *buf;
 	int err;
 
@@ -720,15 +722,31 @@ xal_be_xfs_open(struct xnvme_dev *dev, struct xal **xal)
 		cand->sb.nallocated += be->ags[seqno].agi_count;
 	}
 
-	err =
-	    xal_pool_map(&cand->inodes, 40000000UL, cand->sb.nallocated, sizeof(struct xal_inode));
+	if (opts->shm_name && strlen(opts->shm_name) > XAL_PATH_MAXLEN) {
+		XAL_DEBUG("FAILED: shm_name too long");
+		err = -EINVAL;
+		goto failed;
+	}
+
+	shm = NULL;
+	if (opts->shm_name) {
+		snprintf(shm_name, sizeof(shm_name), "%s_inodes", opts->shm_name);
+		shm = shm_name;
+	}
+	err = xal_pool_map(&cand->inodes, 40000000UL, cand->sb.nallocated, sizeof(struct xal_inode),
+	                   shm);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_map(inodes); err(%d)", err);
 		goto failed;
 	}
 
-	err = xal_pool_map(&cand->extents, 40000000UL, cand->sb.nallocated,
-			   sizeof(struct xal_extent));
+	shm = NULL;
+	if (opts->shm_name) {
+		snprintf(shm_name, sizeof(shm_name), "%s_extents", opts->shm_name);
+		shm = shm_name;
+	}
+	err = xal_pool_map(&cand->extents, 40000000UL, cand->sb.nallocated, sizeof(struct xal_extent),
+	                   shm);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_map(extents); err(%d)", err);
 		goto failed;

--- a/src/xal_pool.c
+++ b/src/xal_pool.c
@@ -32,37 +32,69 @@ xal_pool_grow(struct xal_pool *pool, size_t growby)
 }
 
 int
-xal_pool_map(struct xal_pool *pool, size_t reserved, size_t allocated, size_t element_size)
+xal_pool_map(struct xal_pool *pool, size_t reserved, size_t allocated, size_t element_size,
+             const char *shm_name)
 {
+	size_t nbytes = reserved * element_size;
 	int err;
 
 	if (pool->reserved) {
 		XAL_DEBUG("FAILED: xal_pool_map(...); errno(%d)", EINVAL);
 		return -EINVAL;
 	}
-	if (allocated > reserved) {
-		XAL_DEBUG("FAILED: xal_pool_map(...); errno(%d)", EINVAL);
-		return -EINVAL;
-	}
 
 	pool->reserved = reserved;
-	pool->allocated = 0;
-	pool->growby = allocated;
 	pool->element_size = element_size;
 	pool->free = 0;
 
-	pool->memory =
-	    mmap(NULL, reserved * element_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-	if (MAP_FAILED == pool->memory) {
-		XAL_DEBUG("FAILED: mmap(...); errno(%d)", errno);
-		return -errno;
-	}
+	if (shm_name) {
+		int fd;
 
-	err = xal_pool_grow(pool, allocated);
-	if (err) {
-		XAL_DEBUG("FAILED: xal_pool_grow(...); err(%d)", err);
-		xal_pool_unmap(pool);
-		return err;
+		fd = shm_open(shm_name, O_CREAT | O_RDWR, 0666);
+		if (fd < 0) {
+			XAL_DEBUG("FAILED: shm_open(%s); errno(%d)", shm_name, errno);
+			return -errno;
+		}
+
+		err = ftruncate(fd, nbytes);
+		if (err) {
+			XAL_DEBUG("FAILED: ftruncate(); errno(%d)", errno);
+			close(fd);
+			return -errno;
+		}
+
+		pool->memory = mmap(NULL, nbytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+		close(fd);
+		if (pool->memory == MAP_FAILED) {
+			XAL_DEBUG("FAILED: mmap(); errno(%d)", errno);
+			return -errno;
+		}
+
+		memset(pool->memory, 0, nbytes);
+		pool->allocated = reserved;
+		pool->growby = reserved;
+	} else {
+		if (allocated > reserved) {
+			XAL_DEBUG("FAILED: xal_pool_map(...); errno(%d)", EINVAL);
+			return -EINVAL;
+		}
+
+		pool->allocated = 0;
+		pool->growby = allocated;
+
+		pool->memory =
+		    mmap(NULL, nbytes, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (MAP_FAILED == pool->memory) {
+			XAL_DEBUG("FAILED: mmap(...); errno(%d)", errno);
+			return -errno;
+		}
+
+		err = xal_pool_grow(pool, allocated);
+		if (err) {
+			XAL_DEBUG("FAILED: xal_pool_grow(...); err(%d)", err);
+			xal_pool_unmap(pool);
+			return err;
+		}
 	}
 
 	return 0;

--- a/src/xal_pool.c
+++ b/src/xal_pool.c
@@ -68,18 +68,9 @@ xal_pool_map(struct xal_pool *pool, size_t reserved, size_t allocated, size_t el
 	return 0;
 }
 
-void
-xal_pool_current_inode(struct xal_pool *pool, struct xal_inode **inode)
-{
-	uint8_t *cursor = pool->memory;
-
-	*inode = (void *)&cursor[pool->free * pool->element_size];
-}
-
 int
-xal_pool_claim_inodes(struct xal_pool *pool, size_t count, struct xal_inode **inode)
+xal_pool_claim_inodes(struct xal_pool *pool, size_t count, uint32_t *idx)
 {
-	uint8_t *cursor = pool->memory;
 	int err;
 
 	if (count > pool->growby) {
@@ -95,26 +86,22 @@ xal_pool_claim_inodes(struct xal_pool *pool, size_t count, struct xal_inode **in
 		}
 	}
 
-	if (inode) {
-		*inode = (void *)&cursor[pool->free * pool->element_size];
+	if (pool->free + count > UINT32_MAX) {
+		XAL_DEBUG("FAILED: pool->free exceeds uint32_t range");
+		return -EOVERFLOW;
+	}
+
+	if (idx) {
+		*idx = pool->free;
 	}
 	pool->free += count;
 
 	return 0;
 }
 
-void
-xal_pool_current_extent(struct xal_pool *pool, struct xal_extent **extent)
-{
-	uint8_t *cursor = pool->memory;
-
-	*extent = (void *)&cursor[pool->free * pool->element_size];
-}
-
 int
-xal_pool_claim_extents(struct xal_pool *pool, size_t count, struct xal_extent **extents)
+xal_pool_claim_extents(struct xal_pool *pool, size_t count, uint32_t *idx)
 {
-	uint8_t *cursor = pool->memory;
 	int err;
 
 	if (count > pool->growby) {
@@ -130,8 +117,8 @@ xal_pool_claim_extents(struct xal_pool *pool, size_t count, struct xal_extent **
 		}
 	}
 
-	if (extents) {
-		*extents = (void *)&cursor[pool->free * pool->element_size];
+	if (idx) {
+		*idx = pool->free;
 	}
 	pool->free += count;
 

--- a/src/xal_pool.c
+++ b/src/xal_pool.c
@@ -1,10 +1,12 @@
 #define _GNU_SOURCE
 #include <errno.h>
+#include <fcntl.h>
 #include <libxal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <unistd.h>
 #include <xal_pool.h>
 
 int

--- a/src/xal_pool.c
+++ b/src/xal_pool.c
@@ -10,7 +10,7 @@
 int
 xal_pool_unmap(struct xal_pool *pool)
 {
-	return munmap(pool, pool->reserved);
+	return munmap(pool->memory, pool->reserved * pool->element_size);
 }
 
 int
@@ -141,11 +141,11 @@ xal_pool_claim_extents(struct xal_pool *pool, size_t count, struct xal_extent **
 int
 xal_pool_clear(struct xal_pool *pool)
 {
-	if (mprotect(pool->memory, pool->reserved, PROT_READ | PROT_WRITE)) {
+	if (mprotect(pool->memory, pool->reserved * pool->element_size, PROT_READ | PROT_WRITE)) {
 		XAL_DEBUG("FAILED: mprotect(...); errno(%d)", errno);
 		return -errno;
 	}
-	memset(pool->memory, 0, pool->reserved);
+	memset(pool->memory, 0, pool->reserved * pool->element_size);
 
 	pool->free = 0;
 	pool->allocated = 0;


### PR DESCRIPTION
This PR fixes several bugs in the pool memory implementation, refactors internal addressing to use indices instead of raw pointers, and adds support for sharing pool data across processes via POSIX shared memory.

**Bug fixes**
- Fix xal_pool_unmap, mprotect, and memset calls using wrong pointer and size — they operated on the pool struct itself rather than the backing memory, and omitted the element_size factor from size calculations.
- Add missing include guards to `libxal.h`.

**Refactoring**
- Move LBA block size calculation from `xal_extent_in_lba()` into `xal_open()`, storing the result in `xal_sb.lba_blksze` to avoid recomputing it on every call.
- Replace raw pointers in `xal_inode`, `xal_dentries`, `xal_extents`, and `xal` structs with pool indices. Accessor functions `xal_inode_at()`, `xal_extent_at()`, and `xal_inode_idx()` replace direct pointer arithmetic. This is a prerequisite for shared memory support, as pools can then be mapped at different virtual addresses in different processes.

**New features**
- Add `shm_name` option to `xal_opts`. When set, pool memory is backed by POSIX shared memory objects (<shm_name>_inodes and <shm_name>_extents) with the full reserved size committed upfront. The caller is responsible for `shm_unlink()` when done.
- Add `xal_from_pools()` to construct a lightweight read-only struct xal from externally mapped pool memory. Intended for processes that receive pool memory from an "owner" process via shared memory without needing to open the device or re-run `xal_index()`.
- Add `xal_get_sb()` getter to expose the superblock, needed to pass the metadata to `xal_from_pools()`.

**Documentation**
- Expand the pool memory section in the README to cover lazy growth, shared memory mode, and the usage pattern with `xal_from_pools()`.