### PR TITLE
Inotify

### DIFF
--- a/include/libxal_util.h
+++ b/include/libxal_util.h
@@ -1,6 +1,6 @@
 #ifdef XAL_DEBUG_ENABLED
 
-#define XAL_DEBUG_FCALL(x) x
+#define XAL_DEBUG_FCALL(fn, ...) fn(__VA_ARGS__)
 
 #define __FILENAME__ strrchr("/" __FILE__, '/') + 1
 
@@ -24,7 +24,7 @@
 
 #else
 #define XAL_DEBUG(...)
-#define XAL_DEBUG_FCALL(x)
+#define XAL_DEBUG_FCALL(fn, ...) do {} while (0)
 #endif
 
 #ifdef static_assert

--- a/src/pp.c
+++ b/src/pp.c
@@ -11,6 +11,8 @@
 #include <xal_be_xfs.h>
 #include <xal_odf.h>
 
+#define BMAP_BLOCK_SIZE	512
+
 static int
 xal_be_xfs_pp(struct xal *xal, struct xal_be_xfs *be);
 
@@ -171,6 +173,7 @@ xal_inode_pp(struct xal *xal, struct xal_inode *inode)
 
 	wrtn += printf("xal_inode:\n");
 	wrtn += printf("  ino: 0x%08" PRIX64 "\n", inode->ino);
+	wrtn += printf("  size: %" PRIu64 "\n", inode->size);
 	wrtn += printf("  namelen: %" PRIu8 "\n", inode->namelen);
 	wrtn += printf("  name: '%.256s'\n", inode->name);
 	wrtn += printf("  ftype: %" PRIu8 "\n", inode->ftype);
@@ -188,10 +191,23 @@ xal_inode_pp(struct xal *xal, struct xal_inode *inode)
 		break;
 
 	case XAL_ODF_DIR3_FT_REG_FILE:
+		uint32_t blocksize = xal_get_sb_blocksize(xal);
 		wrtn += printf("  extents.count: %u\n", inode->content.extents.count);
+		for (uint32_t i = 0; i < inode->content.extents.count; ++i) {
+			struct xal_extent *extent = xal_extent_at(xal, inode->content.extents.extent_idx + i);
+	        size_t fofz_begin, fofz_end, bofz_begin, bofz_end;
+
+	        fofz_begin = (extent->start_offset * blocksize) / BMAP_BLOCK_SIZE;
+	        fofz_end = fofz_begin + (extent->nblocks * blocksize) / BMAP_BLOCK_SIZE - 1;
+	        bofz_begin = xal_fsbno_offset(xal, extent->start_block) / BMAP_BLOCK_SIZE;
+	        bofz_end = bofz_begin + (extent->nblocks * blocksize) / BMAP_BLOCK_SIZE - 1;
+			wrtn += printf("- [%" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %"
+				    PRIu64 "]\n", fofz_begin, fofz_end, bofz_begin, bofz_end);
+		}
 		break;
 	}
 
+	fflush(stdout);
 	return wrtn;
 }
 

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -389,6 +389,8 @@ read_fiemap(int fd, struct fiemap **fiemap_ptr)
 	fiemap->fm_extent_count = fiemap->fm_mapped_extents;
 	fiemap->fm_mapped_extents = 0;
 
+	// TODO: writeback could happen between the first and second ioctl.
+	// check that fm_extent_count == fm_mapped_extents. retry if otherwise.
 	if (ioctl(fd, FS_IOC_FIEMAP, fiemap) < 0) {
 		XAL_DEBUG("FAILED: fiemap ioctl(); errno(%d)", errno);
 		return -errno;

--- a/src/xal_be_fiemap_inotify.c
+++ b/src/xal_be_fiemap_inotify.c
@@ -198,7 +198,7 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 			inode = NULL;  // reset the pointer to the inode
 			wd = event->wd;
 
-			XAL_DEBUG_FCALL(inotify_event_mask_pp(event->mask, mask_pp, 128));
+			XAL_DEBUG_FCALL(inotify_event_mask_pp, event->mask, mask_pp, 128);
 			XAL_DEBUG("INFO: mask(%s) for event with wd(%d) and name(%s)", &mask_pp[1], wd, event->name)
 
 			if (inotify->watch_mode == XAL_WATCHMODE_DIRTY_DETECTION) {
@@ -255,7 +255,7 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 				}
 
 				XAL_DEBUG("INFO: reprocessing inode:");
-				XAL_DEBUG_FCALL(xal_inode_pp(xal, inode));
+				XAL_DEBUG_FCALL(xal_inode_pp, xal, inode);
 
 				err = xal_be_fiemap_process_inode_file(xal, path, inode);
 				if (err) {
@@ -264,7 +264,7 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 				}
 
 				XAL_DEBUG("INFO: finished reprocessing inode:");
-				XAL_DEBUG_FCALL(xal_inode_pp(xal, inode));
+				XAL_DEBUG_FCALL(xal_inode_pp, xal, inode);
 
 				atomic_fetch_add(&xal->seq_lock, 1);
 

--- a/src/xal_be_fiemap_inotify.c
+++ b/src/xal_be_fiemap_inotify.c
@@ -182,6 +182,7 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 	char path[XAL_PATH_MAXLEN];
 	khiter_t iter;
 	ssize_t len, i;
+	struct stat st;
 	int err;
 
 	inode_map = inotify->inode_map;
@@ -262,6 +263,15 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 					XAL_DEBUG("FAILED: xal_be_fiemap_process_inode_file(); err(%d)", err);
 					goto failed_with_lock;
 				}
+
+				// Update to new file size
+				err = stat(path, &st);
+				if (err) {
+					XAL_DEBUG("FAILED: stat(%s) errno(%d) while getting new file size", path, errno);
+					err = -errno;
+					goto failed_with_lock;
+				}
+				inode->size = st.st_size;
 
 				XAL_DEBUG("INFO: finished reprocessing inode:");
 				XAL_DEBUG_FCALL(xal_inode_pp, xal, inode);

--- a/src/xal_be_fiemap_inotify.c
+++ b/src/xal_be_fiemap_inotify.c
@@ -133,52 +133,6 @@ xal_be_fiemap_inotify_add_watcher(struct xal_inotify *inotify, char *path, struc
 	return 0;
 }
 
-static int
-_inode_path(struct xal *xal, struct xal_inode *inode, char *path, int *idx)
-{
-	struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
-	int wrtn, err;
-
-	if (!inode) {
-		return -1;
-	}
-	if (inode->parent_idx == XAL_POOL_IDX_NONE) {
-		wrtn = snprintf(path + *idx, XAL_PATH_MAXLEN - *idx, "%s", be->mountpoint);
-		*idx += wrtn;
-		return 0;
-	}
-
-	err = _inode_path(xal, xal_inode_at(xal, inode->parent_idx), path, idx);
-	if (err) {
-		XAL_DEBUG("FAILED: _inode_path()");
-		return err;
-	}
-
-	if (path[*idx - 1] != '/')
-		path[(*idx)++] = '/';
-
-	wrtn = snprintf(path + *idx, XAL_PATH_MAXLEN - *idx, "%s", inode->name);
-	*idx += wrtn;
-
-	return 0;
-}
-
-static int
-get_inode_path(struct xal *xal, struct xal_inode *inode, char *path)
-{
-	int err, idx = 0;
-
-	err = _inode_path(xal, inode, path, &idx);
-	if (err) {
-		XAL_DEBUG("FAILED: _inode_path()");
-		return err;
-	}
-
-	path[idx] = '\0';
-
-	return err;
-}
-
 static __attribute__((unused)) int
 inotify_event_mask_pp(uint32_t mask, char *str, int str_sz) {
 	int wrtn, idx = 0;
@@ -272,12 +226,23 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 					return -EINVAL;
 				}
 
+				if (dir_inode->namelen + 1 + strlen(event->name) + 1 > sizeof(path)) {
+					XAL_DEBUG("FAILED: event(%s) full path too long(%zu)",
+							event->name, dir_inode->namelen + 1 + strlen(event->name) + 1);
+					return -EINVAL;
+				}
+				memcpy(path, dir_inode->name, dir_inode->namelen);
+				path[dir_inode->namelen] = '/';
+				memcpy(path + dir_inode->namelen + 1, event->name, strlen(event->name));
+				path[dir_inode->namelen + 1 + strlen(event->name)] = '\0';
+
+				XAL_DEBUG("INFO: got full path of event: %s", path);
 				atomic_fetch_add(&xal->seq_lock, 1);
 
 				for (uint32_t j = 0; j < dir_inode->content.dentries.count; ++j) {
 					struct xal_inode *child = xal_inode_at(xal, dir_inode->content.dentries.inodes_idx + j);
 
-					if (strcmp(child->name, event->name) == 0) {
+					if (strcmp(child->name, path) == 0) {
 						inode = child;
 						break;
 					}
@@ -286,12 +251,6 @@ check_events(struct xal *xal, struct xal_inotify *inotify)
 				if (!inode) {
 					XAL_DEBUG("FAILED: could not find child with name(%s)", event->name);
 					err = -EINVAL;
-					goto failed_with_lock;
-				}
-
-				err = get_inode_path(xal, inode, path);
-				if (err) {
-					XAL_DEBUG("FAILED: get_inode_path(); err(%d)", err);
 					goto failed_with_lock;
 				}
 


### PR DESCRIPTION
Some minor fixes and debuggability improvements.

- fix(inotify): compare with whole path of the event
struct xal_inode stores absolute paths in their name fields.
However, inotify only gives the file name in event->name.
Resulted in comparing paths vs file names, so no matches were
found even though file names matched.
Fix by converting the event file name to an absolute path before
comparing for matches in the children of the parent directory
of xal's cache.
Also, remove redundant inode_path() function.


- debug(inotify): improve debuggability with extents
Added struct xal * to xal_inode_pp()'s args, so that it prints
all extents for regular files.
Also, flush stdout where printf is used.


- fix(inotify): update inode to new file size
Upon IN_MODIFY or IN_CLOSE_WRITE, file size may have changed.
Update file size in xal's cached inode.
Signed-off-by: Siu Jung [siu.jung@samsung.com](mailto:siu.jung@samsung.com)