### PR TITLE
Misc fixes and util for using shared memory pools in xal

### DIFF
--- a/include/libxal.h
+++ b/include/libxal.h
@@ -290,20 +290,36 @@ int
 xal_index(struct xal *xal);
 
 /**
+ * Callback invoked by the background watch thread immediately after the xal struct is marked
+ * dirty. Dirty means breaking filesystem changes (file creation, deletion, or rename) were
+ * detected, and the in-memory representation is now stale.
+ *
+ * The callback is called from the watch thread; keep it short and thread-safe.
+ *
+ * @param xal     The xal struct that became dirty.
+ * @param cb_args The opaque pointer passed to xal_watch_filesystem().
+ */
+typedef void (*xal_dirty_cb)(struct xal *xal, void *cb_args);
+
+/**
  * Start a background thread listening to inotify events of changes to the file system on the
  * block device.
- * 
+ *
  * Assumes that
  *  - the file system is mounted,
  *  - you have run xal_open() with backend FIEMAP and a watch_mode other than XAL_WATCHMODE_NONE,
  *  - you have indexed the file system with xal_index().
- * 
+ *
  * If these assumptions do not hold, this will result in an error.
- * 
+ *
+ * @param xal     The xal struct obtained when opened with xal_open().
+ * @param cb      Optional callback invoked when xal becomes dirty. May be NULL.
+ * @param cb_args Opaque pointer forwarded to cb. May be NULL.
+ *
  * @returns On success, 0 is returned. On error, negative errno is returned to indicate the error.
  */
 int
-xal_watch_filesystem(struct xal *xal);
+xal_watch_filesystem(struct xal *xal, xal_dirty_cb cb, void *cb_args);
 
 /**
  * Stop the background thread listening to inotify events of changes to the file system on the

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -395,6 +395,24 @@ int
 xal_get_inode(struct xal *xal, char *path, struct xal_inode **inode);
 
 /**
+ * Build a path-to-inode hash map from the in-memory inode tree.
+ *
+ * Intended for use after xal_open() without opts->file_lookupmode not set to 
+ * XAL_FILE_LOOKUPMODE_HASHMAP, or after xal_from_pools(), where xal_index() is not
+ * called but the caller wants constant-time inode lookup via xal_get_inode(). Walks
+ * the existing tree and populates the hash map locally. Any previously existing
+ * map is replaced.
+ *
+ * Note: xal must use backend FIEMAP.
+ *
+ * @param xal The xal struct
+ *
+ * @returns On success, 0 is returned. On error, negative errno is returned to indicate the error.
+ */
+int
+xal_build_lookup_hashmap(struct xal *xal);
+
+/**
  * Retrieve the extents for the file at the given path.
  * 
  * This will search through the tree at xal->root to find the inode. This call fails if the entry

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -258,13 +258,15 @@ xal_close(struct xal *xal);
  * @param mountpoint   Mountpoint of the file system
  * @param inodes_mem   Pointer to the mapped inode pool memory; the root inode must be at index 0
  * @param extents_mem  Pointer to the mapped extent pool memory
+ * @param dirty        Pointer to an atomic bool in shared memory used as the dirty flag; typically
+ *                     the mapping of the {shm_name}_dirty region created by the producer
  * @param out          Output pointer for the constructed xal
  *
  * @return On success, 0. On error, negative errno.
  */
 int
 xal_from_pools(const struct xal_sb *sb, const char *mountpoint, void *inodes_mem,
-	void *extents_mem, struct xal **out);
+	void *extents_mem, _Atomic bool *dirty, struct xal **out);
 
 /**
  * Retrieve inodes from disk and decode the on-disk-format of the retrieved data

--- a/include/xal.h
+++ b/include/xal.h
@@ -31,7 +31,8 @@ struct xal {
 	uint32_t root_idx;       ///< Index of the root inode in the inodes pool
 	struct xal_sb sb;
 	uint8_t be[XAL_BACKEND_SIZE];
-	atomic_bool dirty;       ///< Whether the file system has changed since last index
+	atomic_bool *dirty;      ///< Whether the file system has changed since last index; may point to external shared memory
+	atomic_bool _dirty_storage; ///< Backing store for dirty when no external pointer is provided
 	atomic_int seq_lock;     ///< An uneven number indicates the struct is being modified and is not safe to read
 	bool shared_view;        ///< If true, pool memory is owned externally; xal_close() will not unmap it
 };

--- a/include/xal_be_fiemap_inotify.h
+++ b/include/xal_be_fiemap_inotify.h
@@ -6,6 +6,8 @@ struct xal_inotify {
 	void *inode_map;  ///< Map of inodes from inotify watch descriptors
 	pthread_t watch_thread_id;
 	int flag;
+	xal_dirty_cb cb;
+	void *cb_args;
 };
 
 void

--- a/src/xal.c
+++ b/src/xal.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <xal.h>
@@ -70,7 +71,7 @@ xal_inode_idx(struct xal *xal, struct xal_inode *inode)
 
 int
 xal_from_pools(const struct xal_sb *sb, const char *mountpoint, void *inodes_mem,
-	void *extents_mem, struct xal **out)
+	void *extents_mem, _Atomic bool *dirty, struct xal **out)
 {
 	struct xal *xal;
 
@@ -79,9 +80,15 @@ xal_from_pools(const struct xal_sb *sb, const char *mountpoint, void *inodes_mem
 		return -ENOMEM;
 	}
 
+	if (!dirty) {
+		free(xal);
+		return -EINVAL;
+	}
+
 	xal->sb = *sb;
 	xal->root_idx = 0;
 	xal->shared_view = true;
+	xal->dirty = dirty;
 
 	if (mountpoint) {
 		struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
@@ -125,6 +132,10 @@ xal_close(struct xal *xal)
 
 	xal_pool_unmap(&xal->inodes);
 	xal_pool_unmap(&xal->extents);
+
+	if (xal->dirty != &xal->_dirty_storage) {
+		munmap(xal->dirty, sizeof(atomic_bool));
+	}
 
 	be = (struct xal_backend_base *)&xal->be;
 	if (be->close) {
@@ -235,6 +246,39 @@ xal_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts)
 
 	(*xal)->dev = dev;
 
+	if (opts->shm_name) {
+		char shm_name[XAL_PATH_MAXLEN + 9];
+		int fd;
+		void *mem;
+
+		snprintf(shm_name, sizeof(shm_name), "%s_dirty", opts->shm_name);
+
+		fd = shm_open(shm_name, O_CREAT | O_RDWR, 0666);
+		if (fd < 0) {
+			XAL_DEBUG("FAILED: shm_open(%s); errno(%d)", shm_name, errno);
+			xal_close(*xal);
+			return -errno;
+		}
+
+		err = ftruncate(fd, sizeof(atomic_bool));
+		if (err) {
+			XAL_DEBUG("FAILED: ftruncate(); errno(%d)", errno);
+			close(fd);
+			xal_close(*xal);
+			return -errno;
+		}
+
+		mem = mmap(NULL, sizeof(atomic_bool), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+		close(fd);
+		if (mem == MAP_FAILED) {
+			XAL_DEBUG("FAILED: mmap(); errno(%d)", errno);
+			xal_close(*xal);
+			return -errno;
+		}
+
+		(*xal)->dirty = mem;
+	}
+
 	ns = xnvme_dev_get_ns(dev);
 	if (!ns) {
 		err = -errno;
@@ -269,7 +313,7 @@ _walk(struct xal *xal, struct xal_inode *inode, xal_walk_cb cb_func, void *cb_da
 {
 	int err;
 
-	if (atomic_load(&xal->dirty)) {
+	if (atomic_load(xal->dirty)) {
 		XAL_DEBUG("FAILED: File system has changed");
 		return -ESTALE;
 	}
@@ -319,7 +363,7 @@ xal_get_root(struct xal *xal)
 bool
 xal_is_dirty(struct xal *xal)
 {
-	return atomic_load(&xal->dirty);
+	return atomic_load(xal->dirty);
 }
 
 int

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -645,16 +645,21 @@ search_by_traversal(struct xal *xal, struct xal_inode *root, char *path, struct 
 		memcpy(component, search_begin, search_len);
 		component[search_len] = '\0';
 
+		XAL_DEBUG("Searching for component(%s)", component);
+
 		child = bsearch(component, xal_inode_at(xal, search->content.dentries.inodes_idx),
 				search->content.dentries.count, sizeof(struct xal_inode), compare_name_to_inode);
 
 		if (!child) {
+			XAL_DEBUG("Component(%s) not found", component);
 			break;
 		}
 
 		if (!search_end) {
+			XAL_DEBUG("Final component(%s) found", component);
 			found = child;
 		} else {
+			XAL_DEBUG("Component(%s) found, continuing", component);
 			search = child;
 			search_begin = search_end + 1;
 			search_end = strchr(search_begin, '/');

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -694,6 +694,75 @@ search_by_traversal(struct xal *xal, struct xal_inode *root, char *path, struct 
 	return 0;
 }
 
+static int
+build_hashmap_walk(struct xal *xal, struct xal_inode *inode)
+{
+	struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
+	khash_t(path_to_inode) *map = be->path_inode_map;
+	khiter_t iter;
+	int err;
+
+	if (inode->namelen > 0) {
+		iter = kh_put(path_to_inode, map, inode->name, &err);
+		if (err < 0) {
+			XAL_DEBUG("FAILED: kh_put(%s); err(%d)", inode->name, err);
+			return -EIO;
+		}
+		kh_value(map, iter) = inode;
+	}
+
+	if (xal_inode_is_dir(inode)) {
+		for (uint32_t i = 0; i < inode->content.dentries.count; i++) {
+			struct xal_inode *child = xal_inode_at(xal, inode->content.dentries.inodes_idx + i);
+
+			err = build_hashmap_walk(xal, child);
+			if (err) {
+				return err;
+			}
+		}
+	}
+
+	return 0;
+}
+
+int
+xal_build_lookup_hashmap(struct xal *xal)
+{
+	struct xal_be_fiemap *be;
+	int err;
+
+	if (!xal) {
+		return -EINVAL;
+	}
+
+	be = (struct xal_be_fiemap *)&xal->be;
+
+	if (be->base.type != XAL_BACKEND_FIEMAP) {
+		XAL_DEBUG("FAILED: xal not opened with backend FIEMAP");
+		return -EINVAL;
+	}
+
+	if (be->path_inode_map) {
+		kh_destroy(path_to_inode, be->path_inode_map);
+	}
+
+	be->path_inode_map = kh_init(path_to_inode);
+	if (!be->path_inode_map) {
+		XAL_DEBUG("FAILED: kh_init()");
+		return -ENOMEM;
+	}
+
+	err = build_hashmap_walk(xal, xal_inode_at(xal, xal->root_idx));
+	if (err) {
+		XAL_DEBUG("FAILED: build_hashmap_walk(); err(%d)", err);
+		kh_destroy(path_to_inode, be->path_inode_map);
+		be->path_inode_map = NULL;
+		return err;
+	}
+
+	return 0;
+}
+
 int
 xal_get_inode(struct xal *xal, char *path, struct xal_inode **inode)
 {

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -243,17 +243,17 @@ failed:
 static int
 compare_dirent(const void *a, const void *b)
 {
-	const struct dirent *da = *(const struct dirent **)a;
-	const struct dirent *db = *(const struct dirent **)b;
-	return strcmp(da->d_name, db->d_name);
+	const char *da = *(const char **)a;
+	const char *db = *(const char **)b;
+	return strcmp(da, db);
 }
 
 static int
 xal_be_fiemap_process_inode_dir(struct xal *xal, char *path, struct xal_inode *inode)
 {
 	struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
-	struct dirent **entries = NULL;
 	struct dirent *entry;
+	char **entries = NULL;
 	DIR *d;
 	size_t n_entries = 0, capacity = 0;
 	int err;
@@ -280,6 +280,8 @@ xal_be_fiemap_process_inode_dir(struct xal *xal, char *path, struct xal_inode *i
 
 	entry = readdir(d);
 	while (entry) {
+		char *name;
+
 		if (!_is_directory_member(entry->d_name)) {
 			entry = readdir(d);
 			continue;
@@ -290,7 +292,14 @@ xal_be_fiemap_process_inode_dir(struct xal *xal, char *path, struct xal_inode *i
 			entries = realloc(entries, capacity * sizeof(*entries));
 		}
 
-		entries[n_entries++] = entry;
+		name = strdup(entry->d_name);
+		if (!name) {
+			XAL_DEBUG("FAILED: strdup(); errno(%d)", errno);
+			err = -ENOMEM;
+			goto exit;
+		}
+
+		entries[n_entries++] = name;
 		entry = readdir(d);
 	}
 
@@ -299,18 +308,18 @@ xal_be_fiemap_process_inode_dir(struct xal *xal, char *path, struct xal_inode *i
 	err = xal_pool_claim_inodes(&xal->inodes, n_entries, &inode->content.dentries.inodes_idx);
 	if (err) {
 		XAL_DEBUG("FAILED: xal_pool_claim_inodes(); err(%d)", err);
-		goto failed;
+		goto exit;
 	}
 	inode->content.dentries.count = 0;
 
 	/* Actually process directory entries */
 	for (size_t i = 0; i < n_entries; i++) {
-		entry = entries[i];
+		char *entry_name = entries[i];
 
 		struct xal_inode *dentry = xal_inode_at(xal, inode->content.dentries.inodes_idx + inode->content.dentries.count);
 
-		char dentry_path[strlen(path) + 1 + strlen(entry->d_name) + 1];
-		snprintf(dentry_path, sizeof(dentry_path), "%s/%s", path, entry->d_name);
+		char dentry_path[strlen(path) + 1 + strlen(entry_name) + 1];
+		snprintf(dentry_path, sizeof(dentry_path), "%s/%s", path, entry_name);
 
 		strcpy(dentry->name, dentry_path);
 		dentry->namelen = strlen(dentry->name);
@@ -321,7 +330,7 @@ xal_be_fiemap_process_inode_dir(struct xal *xal, char *path, struct xal_inode *i
 		err = process_ino_fiemap(xal, dentry_path, dentry);
 		if (err) {
 			XAL_DEBUG("FAILED: process_ino_fiemap(); with path(%s)", dentry_path);
-			goto failed;
+			goto exit;
 		}
 	}
 
@@ -332,19 +341,19 @@ xal_be_fiemap_process_inode_dir(struct xal *xal, char *path, struct xal_inode *i
 		iter = kh_put(path_to_inode, map, inode->name, &err);
 		if (err < 0) {
 			XAL_DEBUG("FAILED: kh_put(); err(%d)", err);
-			return -EIO;
+			err = -EIO;
+			goto exit;
 		}
+
 		kh_value(map, iter) = inode;
+		err = 0;
 	}
 
+exit:
 	closedir(d);
-	free(entries);
 
-	return 0;
-
-failed:
-	if (d) {
-		closedir(d);
+	for (size_t i = 0; i < n_entries; i++) {
+		free(entries[i]);
 	}
 	free(entries);
 

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -288,8 +288,17 @@ xal_be_fiemap_process_inode_dir(struct xal *xal, char *path, struct xal_inode *i
 		}
 
 		if (n_entries == capacity) {
+			char **tmp;
+
 			capacity = capacity ? capacity * 2 : 64;
-			entries = realloc(entries, capacity * sizeof(*entries));
+
+			tmp = realloc(entries, capacity * sizeof(*entries));
+			if (!tmp) {
+				XAL_DEBUG("FAILED: realloc(); errno(%d)", errno);
+				err = -ENOMEM;
+				goto exit;
+			}
+			entries = tmp;
 		}
 
 		name = strdup(entry->d_name);

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -145,6 +145,7 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 	}
 
 	cand->root_idx = XAL_POOL_IDX_NONE;
+	cand->dirty = &cand->_dirty_storage;
 
 	be = (struct xal_be_fiemap *)&cand->be;
 
@@ -600,7 +601,7 @@ xal_be_fiemap_index(struct xal *xal)
 		goto exit;
 	}
 
-	atomic_store(&xal->dirty, false);
+	atomic_store(xal->dirty, false);
 
 exit:
 	atomic_fetch_add(&xal->seq_lock, 1);

--- a/src/xal_be_fiemap_inotify.c
+++ b/src/xal_be_fiemap_inotify.c
@@ -320,7 +320,7 @@ background_thread_start(void *arg)
 	}
 
 	while (1) {
-		if (xal->dirty) {
+		if (atomic_load(&xal->dirty)) {
 			continue;
 		}
 
@@ -332,7 +332,10 @@ background_thread_start(void *arg)
 
 		if (err) {
 			XAL_DEBUG("INFO: Found breaking changes, setting xal->dirty to true");
-			xal->dirty = true;
+			atomic_store(&xal->dirty, true);
+			if (be->inotify->cb) {
+				be->inotify->cb(xal, be->inotify->cb_args);
+			}
 		}
 
 	}
@@ -345,7 +348,7 @@ exit_thread:
 }
 
 int
-xal_watch_filesystem(struct xal *xal)
+xal_watch_filesystem(struct xal *xal, xal_dirty_cb cb, void *cb_args)
 {
 	struct xal_backend_base *base;
 	struct xal_be_fiemap *be;
@@ -377,6 +380,9 @@ xal_watch_filesystem(struct xal *xal)
 		XAL_DEBUG("FAILED: Missing call to xal_index()");
 		return -EINVAL;
 	}
+
+	be->inotify->cb = cb;
+	be->inotify->cb_args = cb_args;
 
 	err = pthread_create(&be->inotify->watch_thread_id, NULL, &background_thread_start, xal);
 	if (err) {

--- a/src/xal_be_fiemap_inotify.c
+++ b/src/xal_be_fiemap_inotify.c
@@ -320,7 +320,7 @@ background_thread_start(void *arg)
 	}
 
 	while (1) {
-		if (atomic_load(&xal->dirty)) {
+		if (atomic_load(xal->dirty)) {
 			continue;
 		}
 
@@ -332,7 +332,7 @@ background_thread_start(void *arg)
 
 		if (err) {
 			XAL_DEBUG("INFO: Found breaking changes, setting xal->dirty to true");
-			atomic_store(&xal->dirty, true);
+			atomic_store(xal->dirty, true);
 			if (be->inotify->cb) {
 				be->inotify->cb(xal, be->inotify->cb_args);
 			}

--- a/src/xal_be_xfs.c
+++ b/src/xal_be_xfs.c
@@ -651,6 +651,7 @@ retrieve_and_decode_primary_superblock(struct xnvme_dev *dev, void *buf, struct 
 	}
 
 	cand->root_idx = XAL_POOL_IDX_NONE;
+	cand->dirty = &cand->_dirty_storage;
 
 	be = (struct xal_be_xfs *)&cand->be;
 
@@ -1724,7 +1725,7 @@ xal_be_xfs_index(struct xal *xal)
 		return err;
 	}
 
-	atomic_store(&xal->dirty, false);
+	atomic_store(xal->dirty, false);
 
 	return err;
 }


### PR DESCRIPTION
The callback function will be called when the background thread would mark the xal struct as dirty.