### PR TITLE
feat(xal/shm): replace xal_from_pools with xal_from_shm

### DIFF
--- a/docs/memory-pools.md
+++ b/docs/memory-pools.md
@@ -37,7 +37,7 @@ The process that opened xal with ``shm_name`` set is responsible for calling
 ``shm_unlink()`` on both objects when they are no longer needed.
 ``xal_close()`` will ``munmap`` the regions but will not unlink them.
 
-## Consumer processes: ``xal_from_pools()``
+## Consumer processes: ``xal_from_shm()``
 
 A secondary process that needs read-only access to an already-indexed pool can
 attach to the shared memory objects directly, without opening the device or
@@ -48,18 +48,15 @@ re-running ``xal_index()``. The typical pattern is:
    superblock (via ``xal_get_sb()``) to the other process, for example
    through a Unix socket or another shared memory region.
 
-2. The other process maps both shared memory objects with ``shm_open()`` and
-   ``mmap(MAP_SHARED)``.
-
-3. It then calls ``xal_from_pools()`` with the received superblock and the
-   two mapped memory regions to obtain a read-only ``struct xal *``::
+2. It then calls ``xal_from_shm()`` with the received superblock and shared
+   memory region name to obtain a read-only ``struct xal *``::
 
       const struct xal_sb *sb = /* superblock communicated OOB */;
-      void *inodes_mem = /* mmap of /myapp_xal_inodes */;
-      void *extents_mem = /* mmap of /myapp_xal_extents */;
+      const char *shm_name = /* shared memory region name */;
+      const char *mountpoint = /* mountpoint of block device, if opened with FIEMAP backend */;
       struct xal *view;
 
-      xal_from_pools(sb, NULL, inodes_mem, extents_mem, &view);
+      xal_from_shm(shm_name, sb, mountpoint, &view);
       xal_walk(view, xal_get_root(view), my_callback, NULL);
       xal_close(view); /* frees the struct; does NOT munmap or unlink */
 

--- a/docs/memory-pools.md
+++ b/docs/memory-pools.md
@@ -33,9 +33,6 @@ respectively::
 In this mode the full reserved size is committed upfront via ``ftruncate()``
 and ``mmap(MAP_SHARED)``; there is no lazy growth. The objects persist in the
 shared memory filesystem (``/dev/shm`` on Linux) until explicitly removed.
-The process that opened xal with ``shm_name`` set is responsible for calling
-``shm_unlink()`` on both objects when they are no longer needed.
-``xal_close()`` will ``munmap`` the regions but will not unlink them.
 
 ## Consumer processes: ``xal_from_shm()``
 
@@ -58,10 +55,4 @@ re-running ``xal_index()``. The typical pattern is:
 
       xal_from_shm(shm_name, sb, mountpoint, &view);
       xal_walk(view, xal_get_root(view), my_callback, NULL);
-      xal_close(view); /* frees the struct; does NOT munmap or unlink */
-
-The resulting ``struct xal`` has ``shared_view`` set to ``true``.
-``xal_close()`` on a shared view frees only the ``struct xal`` allocation;
-the pool memory regions are left mapped and must be unmapped by the caller.
-The process that created the shared memory objects is responsible for
-``shm_unlink()``.
+      xal_close(view);

--- a/docs/memory-pools.md
+++ b/docs/memory-pools.md
@@ -38,21 +38,24 @@ shared memory filesystem (``/dev/shm`` on Linux) until explicitly removed.
 
 A secondary process that needs read-only access to an already-indexed pool can
 attach to the shared memory objects directly, without opening the device or
-re-running ``xal_index()``. The typical pattern is:
+re-running ``xal_index()``. All metadata (superblock, backend type, mountpoint,
+root inode index) is read from a dedicated ``_state`` shared memory region
+created by the primary; no out-of-band communication is needed beyond the base
+shared memory name.
+
+The typical pattern is:
 
 1. One process calls ``xal_open()`` with ``shm_name`` set and runs
-   ``xal_index()``. It then communicates the shared memory names and the
-   superblock (via ``xal_get_sb()``) to the other process, for example
-   through a Unix socket or another shared memory region.
+   ``xal_index()``. The shared memory name must be communicated to the
+   secondary process, for example through a command-line argument or
+   environment variable.
 
-2. It then calls ``xal_from_shm()`` with the received superblock and shared
-   memory region name to obtain a read-only ``struct xal *``::
+2. The secondary calls ``xal_from_shm()`` with that name to obtain a
+   read-only ``struct xal *``::
 
-      const struct xal_sb *sb = /* superblock communicated OOB */;
-      const char *shm_name = /* shared memory region name */;
-      const char *mountpoint = /* mountpoint of block device, if opened with FIEMAP backend */;
+      const char *shm_name = /* shared memory base name */;
       struct xal *view;
 
-      xal_from_shm(shm_name, sb, mountpoint, &view);
+      xal_from_shm(shm_name, &view);
       xal_walk(view, xal_get_root(view), my_callback, NULL);
       xal_close(view);

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -246,29 +246,6 @@ void
 xal_close(struct xal *xal);
 
 /**
- * Construct a read-only xal from externally provided pool memory.
- *
- * Intended for processes that receive pool memory via POSIX shared memory from elsewhere.
- * The caller is responsible for mapping the shared memory regions before calling this with the
- * shm_name given in the xal_opts.
- * The resulting xal can be closed with xal_close(), which will free the struct xal allocation but
- * will not munmap or unlink the pool memory regions — that remains the caller's responsibility.
- *
- * @param sb           Superblock metadata
- * @param mountpoint   Mountpoint of the file system
- * @param inodes_mem   Pointer to the mapped inode pool memory; the root inode must be at index 0
- * @param extents_mem  Pointer to the mapped extent pool memory
- * @param dirty        Pointer to an atomic bool in shared memory used as the dirty flag; typically
- *                     the mapping of the {shm_name}_dirty region created by the producer
- * @param out          Output pointer for the constructed xal
- *
- * @return On success, 0. On error, negative errno.
- */
-int
-xal_from_pools(const struct xal_sb *sb, const char *mountpoint, void *inodes_mem,
-	void *extents_mem, _Atomic bool *dirty, struct xal **out);
-
-/**
  * Retrieve inodes from disk and decode the on-disk-format of the retrieved data
  *
  * @param xal Pointer to the xal
@@ -354,6 +331,24 @@ xal_walk(struct xal *xal, struct xal_inode *inode, xal_walk_cb cb_func, void *cb
 
 uint64_t
 xal_fsbno_offset(struct xal *xal, uint64_t fsbno);
+
+/**
+ * Construct a read-only xal from externally provided shared memory.
+ *
+ * Intended for multi-process support, where a primary process has built the xal tree with
+ * opts->shm_name set.
+ * The resulting xal can be closed with xal_close(), which will free the struct xal allocation and
+ * munmap the pool memory regions.
+ *
+ * @param shm_name	   ID for shared memory region that the primary process used
+ * @param sb           Superblock metadata
+ * @param mountpoint   Mountpoint of the file system
+ * @param out          Output pointer for the constructed xal
+ *
+ * @return On success, 0. On error, negative errno.
+ */
+int
+xal_from_shm(const char *shm_name, const struct xal_sb *sb, const char *mountpoint, struct xal **out);
 
 int
 xal_inode_path_pp(struct xal *xal, struct xal_inode *inode);

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -333,22 +333,21 @@ uint64_t
 xal_fsbno_offset(struct xal *xal, uint64_t fsbno);
 
 /**
- * Construct a read-only xal from externally provided shared memory.
+ * Construct a read-only xal from shared memory created by a primary process.
  *
  * Intended for multi-process support, where a primary process has built the xal tree with
- * opts->shm_name set.
+ * opts->shm_name set and called xal_index(). All metadata (superblock, backend type, mountpoint,
+ * root index) is read from the shared state region; no out-of-band communication is required.
  * The resulting xal can be closed with xal_close(), which will free the struct xal allocation and
- * munmap the pool memory regions.
+ * munmap the shared memory regions.
  *
- * @param shm_name	   ID for shared memory region that the primary process used
- * @param sb           Superblock metadata
- * @param mountpoint   Mountpoint of the file system
+ * @param shm_name	   Base name for the shared memory regions (same value as opts->shm_name)
  * @param out          Output pointer for the constructed xal
  *
  * @return On success, 0. On error, negative errno.
  */
 int
-xal_from_shm(const char *shm_name, const struct xal_sb *sb, const char *mountpoint, struct xal **out);
+xal_from_shm(const char *shm_name, struct xal **out);
 
 int
 xal_inode_path_pp(struct xal *xal, struct xal_inode *inode);

--- a/include/xal.h
+++ b/include/xal.h
@@ -16,9 +16,16 @@ struct xal_backend_base {
 	void (*close)(struct xal *xal);
 };
 
+struct xal_shared_state {
+	enum xal_backend type;
+	struct xal_sb sb;
+	char mountpoint[XAL_PATH_MAXLEN];
+	atomic_bool dirty;
+};
+
 /**
  * XAL
- * 
+ *
  * Contains a handle to the storage device along with meta-data describing the data-layout and a
  * pool of inodes.
  *
@@ -32,7 +39,9 @@ struct xal {
 	struct xal_sb sb;
 	uint8_t be[XAL_BACKEND_SIZE];
 	atomic_bool *dirty;      ///< Whether the file system has changed since last index; may point to external shared memory
-	atomic_bool _dirty_storage; ///< Backing store for dirty when no external pointer is provided
+	atomic_bool _dirty_storage; ///< Backing store for dirty when shm_name is not set
 	atomic_int seq_lock;     ///< An uneven number indicates the struct is being modified and is not safe to read
 	bool shared_view;        ///< If true, pool memory is owned externally; xal_close() will not unmap it
+	struct xal_shared_state *state; ///< Mapped shared state region; non-NULL when shm_name was set
+	char *state_shm_name;           ///< Name of the _state shm region; set by primary only, for unlink on close
 };

--- a/include/xal_be_xfs.h
+++ b/include/xal_be_xfs.h
@@ -26,5 +26,8 @@ struct xal_be_xfs {
 };
 XAL_STATIC_ASSERT(sizeof(struct xal_be_xfs) == XAL_BACKEND_SIZE, "Incorrect size");
 
+void
+xal_be_xfs_close(struct xal *xal);
+
 int
 xal_be_xfs_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts);

--- a/include/xal_pool.h
+++ b/include/xal_pool.h
@@ -13,11 +13,12 @@ struct xal_pool {
 	size_t growby;	     ///< Number of reserved elements to allocate at a time
 	size_t free;	     ///< Index / position of the next free element
 	size_t element_size; ///< Size of a single element in bytes
+	char *shm_name;      ///< Name of shared memory region, may be NULL
 	void *memory;	     ///< Memory space for elements
 };
 
 int
-xal_pool_unmap(struct xal_pool *pool);
+xal_pool_unmap(struct xal_pool *pool, bool unlink);
 
 /**
  * Initialize the given pool of 'struct xal_inode'
@@ -32,8 +33,7 @@ xal_pool_unmap(struct xal_pool *pool);
  *
  * If shm_name is NULL, uses private anonymous memory with lazy mprotect growth.
  * If shm_name is non-NULL, backs the pool with a POSIX shared memory object of that name.
- * In the shm case the full reserved size is committed upfront and the caller is responsible
- * for shm_unlink() when the shm is no longer needed.
+ * In the shm case the full reserved size is committed upfront.
  */
 int
 xal_pool_map(struct xal_pool *pool, size_t reserved, size_t allocated, size_t element_size,

--- a/src/xal.c
+++ b/src/xal.c
@@ -69,64 +69,12 @@ xal_inode_idx(struct xal *xal, struct xal_inode *inode)
 	return (uint32_t)(inode - (struct xal_inode *)xal->inodes.memory);
 }
 
-int
-xal_from_pools(const struct xal_sb *sb, const char *mountpoint, void *inodes_mem,
-	void *extents_mem, _Atomic bool *dirty, struct xal **out)
-{
-	struct xal *xal;
-
-	xal = calloc(1, sizeof(*xal));
-	if (!xal) {
-		return -ENOMEM;
-	}
-
-	if (!dirty) {
-		free(xal);
-		return -EINVAL;
-	}
-
-	xal->sb = *sb;
-	xal->root_idx = 0;
-	xal->shared_view = true;
-	xal->dirty = dirty;
-
-	if (mountpoint) {
-		struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
-		be->base.type = XAL_BACKEND_FIEMAP;
-		be->base.close = xal_be_fiemap_close;
-		be->mountpoint = strdup(mountpoint);
-		if (!be->mountpoint) {
-			free(xal);
-			return -ENOMEM;
-		}
-	}
-
-	xal->inodes.memory = inodes_mem;
-	xal->inodes.element_size = sizeof(struct xal_inode);
-
-	xal->extents.memory = extents_mem;
-	xal->extents.element_size = sizeof(struct xal_extent);
-
-	*out = xal;
-
-	return 0;
-}
-
 void
 xal_close(struct xal *xal)
 {
 	struct xal_backend_base *be;
 
 	if (!xal) {
-		return;
-	}
-
-	if (xal->shared_view) {
-		be = (struct xal_backend_base *)&xal->be;
-		if (be->close) {
-			be->close(xal);
-		}
-		free(xal);
 		return;
 	}
 
@@ -382,6 +330,153 @@ uint32_t
 xal_get_sb_blocksize(struct xal *xal)
 {
 	return xal->sb.blocksize;
+}
+
+int
+xal_from_shm(const char *shm_name, const struct xal_sb *sb, const char *mountpoint, struct xal **out)
+{
+	struct xal *xal;
+	struct stat st;
+	char shm_name_inodes[128], shm_name_extents[128], shm_name_dirty[128];
+	size_t inodes_size, extents_size;
+	_Atomic bool *dirty;
+	void *inodes_mem, *extents_mem;
+	int shm_fd = -1, err;
+
+	xal = calloc(1, sizeof(*xal));
+	if (!xal) {
+		return -ENOMEM;
+	}
+
+	xal->sb = *sb;
+	xal->root_idx = 0;
+	xal->shared_view = true;
+
+	snprintf(shm_name_inodes, sizeof(shm_name_inodes), "%s_inodes", shm_name);
+	snprintf(shm_name_extents, sizeof(shm_name_extents), "%s_extents", shm_name);
+	snprintf(shm_name_dirty, sizeof(shm_name_dirty), "%s_dirty", shm_name);
+
+	/* DIRTY */
+	shm_fd = shm_open(shm_name_dirty, O_RDONLY, 0);
+	if (shm_fd < 0) {
+		err = -errno;
+		fprintf(stderr, "Failed: shm_open(dirty); err(%d)\n", err);
+		goto failed;
+	}
+
+	dirty = mmap(NULL, sizeof(atomic_bool), PROT_READ, MAP_SHARED, shm_fd, 0);
+
+	close(shm_fd);
+	shm_fd = -1;
+
+	if (dirty == MAP_FAILED) {
+		err = -errno;
+		fprintf(stderr, "Failed: mmap(dirty); err(%d)\n", err);
+		goto failed;
+	}
+
+	xal->dirty = dirty;
+
+	if (atomic_load(xal->dirty)) {
+		err = -EINVAL;
+		goto unmap_dirty;
+	}
+
+	/* INODES */
+	shm_fd = shm_open(shm_name_inodes, O_RDONLY, 0);
+	if (shm_fd < 0) {
+		err = -errno;
+		fprintf(stderr, "Failed: shm_open(inodes); err(%d)\n", err);
+		goto unmap_dirty;
+	}
+
+	err = fstat(shm_fd, &st);
+	if (err) {
+		err = -errno;
+		fprintf(stderr, "Failed: fstat(inodes); err(%d)\n", err);
+		goto unmap_dirty;
+	}
+
+	inodes_size = st.st_size;
+	inodes_mem = mmap(NULL, st.st_size, PROT_READ, MAP_SHARED, shm_fd, 0);
+
+	close(shm_fd);
+	shm_fd = -1;
+
+	if (inodes_mem == MAP_FAILED) {
+		err = -errno;
+		fprintf(stderr, "Failed: mmap(inodes); err(%d)\n", err);
+		goto unmap_dirty;
+	}
+
+	xal->inodes.memory = inodes_mem;
+	xal->inodes.element_size = sizeof(struct xal_inode);
+	xal->inodes.reserved = inodes_size / xal->inodes.element_size;
+
+	/* EXTENTS */
+	shm_fd = shm_open(shm_name_extents, O_RDONLY, 0);
+	if (shm_fd < 0) {
+		err = -errno;
+		fprintf(stderr, "Failed: shm_open(extents); err(%d)\n", err);
+		goto unmap_inodes;
+	}
+
+	err = fstat(shm_fd, &st);
+	if (err) {
+		err = -errno;
+		fprintf(stderr, "Failed: fstat(extents); err(%d)\n", err);
+		goto unmap_inodes;
+	}
+
+	extents_size = st.st_size;
+	extents_mem = mmap(NULL, extents_size, PROT_READ, MAP_SHARED, shm_fd, 0);
+
+	close(shm_fd);
+	shm_fd = -1;
+
+	if (extents_mem == MAP_FAILED) {
+		err = -errno;
+		fprintf(stderr, "Failed: mmap(extents); err(%d)\n", err);
+		goto unmap_inodes;
+	}
+
+	xal->extents.memory = extents_mem;
+	xal->extents.element_size = sizeof(struct xal_extent);
+	xal->extents.reserved = extents_size / xal->extents.element_size;
+
+	if (mountpoint) {
+		struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
+		be->base.type = XAL_BACKEND_FIEMAP;
+		be->base.close = xal_be_fiemap_close;
+		be->mountpoint = strdup(mountpoint);
+		if (!be->mountpoint) {
+			err = -ENOMEM;
+			goto unmap_extents;
+		}
+	} else {
+		struct xal_be_xfs *be = (struct xal_be_xfs *)&xal->be;
+		be->base.type = XAL_BACKEND_XFS;
+		be->base.close = xal_be_xfs_close;
+	}
+
+	*out = xal;
+
+	return 0;
+
+unmap_extents:
+	munmap(extents_mem, extents_size);
+unmap_inodes:
+	munmap(inodes_mem, inodes_size);
+unmap_dirty:
+	munmap(dirty, sizeof(atomic_bool));
+failed:
+	free(xal);
+
+	if (shm_fd >= 0) {
+		close(shm_fd);
+	}
+
+	return err;
 }
 
 int

--- a/src/xal.c
+++ b/src/xal.c
@@ -78,8 +78,8 @@ xal_close(struct xal *xal)
 		return;
 	}
 
-	xal_pool_unmap(&xal->inodes);
-	xal_pool_unmap(&xal->extents);
+	xal_pool_unmap(&xal->inodes, !xal->shared_view);
+	xal_pool_unmap(&xal->extents, !xal->shared_view);
 
 	if (xal->dirty != &xal->_dirty_storage) {
 		munmap(xal->dirty, sizeof(atomic_bool));

--- a/src/xal.c
+++ b/src/xal.c
@@ -81,8 +81,12 @@ xal_close(struct xal *xal)
 	xal_pool_unmap(&xal->inodes, !xal->shared_view);
 	xal_pool_unmap(&xal->extents, !xal->shared_view);
 
-	if (xal->dirty != &xal->_dirty_storage) {
-		munmap(xal->dirty, sizeof(atomic_bool));
+	if (xal->state) {
+		if (xal->state_shm_name) {
+			shm_unlink(xal->state_shm_name);
+			free(xal->state_shm_name);
+		}
+		munmap(xal->state, sizeof(struct xal_shared_state));
 	}
 
 	be = (struct xal_backend_base *)&xal->be;
@@ -194,39 +198,6 @@ xal_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts)
 
 	(*xal)->dev = dev;
 
-	if (opts->shm_name) {
-		char shm_name[XAL_PATH_MAXLEN + 9];
-		int fd;
-		void *mem;
-
-		snprintf(shm_name, sizeof(shm_name), "%s_dirty", opts->shm_name);
-
-		fd = shm_open(shm_name, O_CREAT | O_RDWR, 0666);
-		if (fd < 0) {
-			XAL_DEBUG("FAILED: shm_open(%s); errno(%d)", shm_name, errno);
-			xal_close(*xal);
-			return -errno;
-		}
-
-		err = ftruncate(fd, sizeof(atomic_bool));
-		if (err) {
-			XAL_DEBUG("FAILED: ftruncate(); errno(%d)", errno);
-			close(fd);
-			xal_close(*xal);
-			return -errno;
-		}
-
-		mem = mmap(NULL, sizeof(atomic_bool), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-		close(fd);
-		if (mem == MAP_FAILED) {
-			XAL_DEBUG("FAILED: mmap(); errno(%d)", errno);
-			xal_close(*xal);
-			return -errno;
-		}
-
-		(*xal)->dirty = mem;
-	}
-
 	ns = xnvme_dev_get_ns(dev);
 	if (!ns) {
 		err = -errno;
@@ -240,6 +211,53 @@ xal_open(struct xnvme_dev *dev, struct xal **xal, struct xal_opts *opts)
 	}
 
 	(*xal)->sb.lba_blksze = 1U << ns->lbaf[fidx].ds;
+
+	if (opts->shm_name) {
+		char shm_name_state[XAL_PATH_MAXLEN + 9];
+		struct xal_shared_state *state;
+		int fd;
+
+		snprintf(shm_name_state, sizeof(shm_name_state), "%s_state", opts->shm_name);
+
+		fd = shm_open(shm_name_state, O_CREAT | O_RDWR, 0666);
+		if (fd < 0) {
+			XAL_DEBUG("FAILED: shm_open(%s); errno(%d)", shm_name_state, errno);
+			xal_close(*xal);
+			return -errno;
+		}
+
+		err = ftruncate(fd, sizeof(struct xal_shared_state));
+		if (err) {
+			XAL_DEBUG("FAILED: ftruncate(); errno(%d)", errno);
+			close(fd);
+			xal_close(*xal);
+			return -errno;
+		}
+
+		state = mmap(NULL, sizeof(struct xal_shared_state), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+		close(fd);
+		if (state == MAP_FAILED) {
+			XAL_DEBUG("FAILED: mmap(); errno(%d)", errno);
+			xal_close(*xal);
+			return -errno;
+		}
+
+		(*xal)->state_shm_name = strdup(shm_name_state);
+		if (!(*xal)->state_shm_name) {
+			XAL_DEBUG("FAILED: strdup(); errno(%d)", errno);
+			munmap(state, sizeof(struct xal_shared_state));
+			xal_close(*xal);
+			return -ENOMEM;
+		}
+
+		(*xal)->state = state;
+		(*xal)->dirty = &state->dirty;
+
+		state->type = opts->be;
+		state->sb = (*xal)->sb;
+		strncpy(state->mountpoint, mountpoint, XAL_PATH_MAXLEN - 1);
+		state->mountpoint[XAL_PATH_MAXLEN - 1] = '\0';
+	}
 
 	return 0;
 }
@@ -333,13 +351,13 @@ xal_get_sb_blocksize(struct xal *xal)
 }
 
 int
-xal_from_shm(const char *shm_name, const struct xal_sb *sb, const char *mountpoint, struct xal **out)
+xal_from_shm(const char *shm_name, struct xal **out)
 {
 	struct xal *xal;
+	struct xal_shared_state *state;
 	struct stat st;
-	char shm_name_inodes[128], shm_name_extents[128], shm_name_dirty[128];
+	char shm_name_inodes[128], shm_name_extents[128], shm_name_state[128];
 	size_t inodes_size, extents_size;
-	_Atomic bool *dirty;
 	void *inodes_mem, *extents_mem;
 	int shm_fd = -1, err;
 
@@ -348,38 +366,37 @@ xal_from_shm(const char *shm_name, const struct xal_sb *sb, const char *mountpoi
 		return -ENOMEM;
 	}
 
-	xal->sb = *sb;
-	xal->root_idx = 0;
 	xal->shared_view = true;
 
 	snprintf(shm_name_inodes, sizeof(shm_name_inodes), "%s_inodes", shm_name);
 	snprintf(shm_name_extents, sizeof(shm_name_extents), "%s_extents", shm_name);
-	snprintf(shm_name_dirty, sizeof(shm_name_dirty), "%s_dirty", shm_name);
+	snprintf(shm_name_state, sizeof(shm_name_state), "%s_state", shm_name);
 
-	/* DIRTY */
-	shm_fd = shm_open(shm_name_dirty, O_RDONLY, 0);
+	/* STATE */
+	shm_fd = shm_open(shm_name_state, O_RDONLY, 0);
 	if (shm_fd < 0) {
 		err = -errno;
-		fprintf(stderr, "Failed: shm_open(dirty); err(%d)\n", err);
+		fprintf(stderr, "Failed: shm_open(state); err(%d)\n", err);
 		goto failed;
 	}
 
-	dirty = mmap(NULL, sizeof(atomic_bool), PROT_READ, MAP_SHARED, shm_fd, 0);
-
+	state = mmap(NULL, sizeof(struct xal_shared_state), PROT_READ, MAP_SHARED, shm_fd, 0);
 	close(shm_fd);
 	shm_fd = -1;
 
-	if (dirty == MAP_FAILED) {
+	if (state == MAP_FAILED) {
 		err = -errno;
-		fprintf(stderr, "Failed: mmap(dirty); err(%d)\n", err);
+		fprintf(stderr, "Failed: mmap(state); err(%d)\n", err);
 		goto failed;
 	}
 
-	xal->dirty = dirty;
+	xal->state = state;
+	xal->dirty = &state->dirty;
+	xal->sb = state->sb;
 
 	if (atomic_load(xal->dirty)) {
 		err = -EINVAL;
-		goto unmap_dirty;
+		goto unmap_state;
 	}
 
 	/* INODES */
@@ -387,26 +404,25 @@ xal_from_shm(const char *shm_name, const struct xal_sb *sb, const char *mountpoi
 	if (shm_fd < 0) {
 		err = -errno;
 		fprintf(stderr, "Failed: shm_open(inodes); err(%d)\n", err);
-		goto unmap_dirty;
+		goto unmap_state;
 	}
 
 	err = fstat(shm_fd, &st);
 	if (err) {
 		err = -errno;
 		fprintf(stderr, "Failed: fstat(inodes); err(%d)\n", err);
-		goto unmap_dirty;
+		goto unmap_state;
 	}
 
 	inodes_size = st.st_size;
 	inodes_mem = mmap(NULL, st.st_size, PROT_READ, MAP_SHARED, shm_fd, 0);
-
 	close(shm_fd);
 	shm_fd = -1;
 
 	if (inodes_mem == MAP_FAILED) {
 		err = -errno;
 		fprintf(stderr, "Failed: mmap(inodes); err(%d)\n", err);
-		goto unmap_dirty;
+		goto unmap_state;
 	}
 
 	xal->inodes.memory = inodes_mem;
@@ -430,7 +446,6 @@ xal_from_shm(const char *shm_name, const struct xal_sb *sb, const char *mountpoi
 
 	extents_size = st.st_size;
 	extents_mem = mmap(NULL, extents_size, PROT_READ, MAP_SHARED, shm_fd, 0);
-
 	close(shm_fd);
 	shm_fd = -1;
 
@@ -444,11 +459,11 @@ xal_from_shm(const char *shm_name, const struct xal_sb *sb, const char *mountpoi
 	xal->extents.element_size = sizeof(struct xal_extent);
 	xal->extents.reserved = extents_size / xal->extents.element_size;
 
-	if (mountpoint) {
+	if (state->type == XAL_BACKEND_FIEMAP) {
 		struct xal_be_fiemap *be = (struct xal_be_fiemap *)&xal->be;
 		be->base.type = XAL_BACKEND_FIEMAP;
 		be->base.close = xal_be_fiemap_close;
-		be->mountpoint = strdup(mountpoint);
+		be->mountpoint = strdup(state->mountpoint);
 		if (!be->mountpoint) {
 			err = -ENOMEM;
 			goto unmap_extents;
@@ -467,8 +482,8 @@ unmap_extents:
 	munmap(extents_mem, extents_size);
 unmap_inodes:
 	munmap(inodes_mem, inodes_size);
-unmap_dirty:
-	munmap(dirty, sizeof(atomic_bool));
+unmap_state:
+	munmap(state, sizeof(struct xal_shared_state));
 failed:
 	free(xal);
 

--- a/src/xal_pool.c
+++ b/src/xal_pool.c
@@ -10,9 +10,27 @@
 #include <xal_pool.h>
 
 int
-xal_pool_unmap(struct xal_pool *pool)
+xal_pool_unmap(struct xal_pool *pool, bool unlink)
 {
-	return munmap(pool->memory, pool->reserved * pool->element_size);
+	int err;
+	
+	err = munmap(pool->memory, pool->reserved * pool->element_size);
+	if (err < 0) {
+		err = -errno;
+		XAL_DEBUG("FAILED: mprotmunmapect(...); errno(%d)", errno);
+		return err;
+	}
+
+	if (pool->shm_name && unlink) {
+		err = shm_unlink(pool->shm_name);
+		if (err < 0) {
+			err = -errno;
+			XAL_DEBUG("FAILED: shm_unlink(...); errno(%d)", errno);
+			return err;
+		}
+	}
+
+	return 0;
 }
 
 int
@@ -71,10 +89,16 @@ xal_pool_map(struct xal_pool *pool, size_t reserved, size_t allocated, size_t el
 			XAL_DEBUG("FAILED: mmap(); errno(%d)", errno);
 			return -errno;
 		}
-
 		memset(pool->memory, 0, nbytes);
+
 		pool->allocated = reserved;
 		pool->growby = reserved;
+		
+		pool->shm_name = strdup(shm_name);
+		if (!pool->shm_name) {
+			XAL_DEBUG("FAILED: strdup(); errbo(%d)", errno);
+			return -errno;
+		}
 	} else {
 		if (allocated > reserved) {
 			XAL_DEBUG("FAILED: xal_pool_map(...); errno(%d)", EINVAL);
@@ -94,7 +118,7 @@ xal_pool_map(struct xal_pool *pool, size_t reserved, size_t allocated, size_t el
 		err = xal_pool_grow(pool, allocated);
 		if (err) {
 			XAL_DEBUG("FAILED: xal_pool_grow(...); err(%d)", err);
-			xal_pool_unmap(pool);
+			xal_pool_unmap(pool, false);
 			return err;
 		}
 	}


### PR DESCRIPTION
This commit moves the responsibility for mapping shared memory from the user to to the xal itself. This ensures symmetry, as this was already the case for "primary" processes.