### PR TITLE
thaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Dependencies:
 
 - `xnvme` >= 0.7.0 -- must be installed and visible to `pkg-config`
 - `librt`
+- `libbpf`, `libelf`, `zlib` (for the BPF event listener)
+- `clang`, `llvm`, and `bpftool` (to compile BPF objects and generate skeletons)
+- A kernel exposing BTF at `/sys/kernel/btf/vmlinux` (i.e. built with `CONFIG_DEBUG_INFO_BTF=y`)
 
 The default `make` target runs clean, configure, build, and install in one
 shot:

--- a/include/libxal.h
+++ b/include/libxal.h
@@ -444,4 +444,44 @@ xal_get_extents(struct xal *xal, char *path, struct xal_extents **extents);
 int
 xal_get_dentries(struct xal *xal, char *path, struct xal_dentries **dentries);
 
+/**
+ * Start a background thread polling the BPF ring buffer for filesystem events
+ * (e.g. unfreeze) on the block device.
+ *
+ * Assumes that
+ *  - you have run xal_open() with backend FIEMAP and BPF event listening enabled,
+ *  - the BPF skeleton and ring buffer have been initialized.
+ *
+ * If the thread is already running, this is a no-op and 0 is returned.
+ *
+ * @param xal The xal struct obtained when opened with xal_open().
+ *
+ * @returns On success, 0 is returned. On error, a negative errno is returned to indicate the
+ *          error: -EINVAL if xal is NULL; -ENOTSUP if the backend is not FIEMAP; -ENODEV if xal
+ *          was not opened with BPF event listening; -ENOTCONN if the BPF skeleton is not
+ *          initialized; -ENOBUFS if the ring buffer is not initialized; or the negated errno
+ *          from pthread_create() if thread creation fails.
+ */
+int
+xal_bpf_start_poll_thread(struct xal *xal);
+
+/**
+ * Stop the background thread polling the BPF ring buffer.
+ *
+ * Assumes that
+ *  - you have run xal_open() with backend FIEMAP and BPF event listening enabled,
+ *  - the background thread is running, see xal_bpf_start_poll_thread().
+ *
+ * If these assumptions do not hold, this will result in an error.
+ *
+ * @param xal The xal struct obtained when opened with xal_open().
+ *
+ * @returns On success, 0 is returned. On error, a negative errno is returned to indicate the
+ *          error: -EINVAL if xal is NULL; -ENOTSUP if the backend is not FIEMAP; -ENODEV if xal
+ *          was not opened with BPF event listening; -ENOTCONN if the BPF skeleton is not
+ *          initialized; -ESRCH if the background thread is not running; or the negated errno
+ *          from pthread_join() if joining the thread fails.
+ */
+int
+xal_bpf_stop_poll_thread(struct xal *xal);
 #endif /* LIBXAL_H */

--- a/include/xal_be_fiemap.h
+++ b/include/xal_be_fiemap.h
@@ -2,9 +2,10 @@ struct xal_be_fiemap {
 	struct xal_backend_base base;
 	char *mountpoint;      ///< Path to mountpoint of dev
 	struct xal_inotify *inotify;
+	struct xal_bpf *bpf;
 	void *path_inode_map;  ///< Map of paths to inodes
 
-	uint8_t _rsvd[16];
+	uint8_t _rsvd[8];
 };
 XAL_STATIC_ASSERT(sizeof(struct xal_be_fiemap) == XAL_BACKEND_SIZE, "Incorrect size");
 

--- a/include/xal_bpf.h
+++ b/include/xal_bpf.h
@@ -1,0 +1,24 @@
+#ifndef XAL_BPF_H
+#define XAL_BPF_H
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+struct xal_bpf {
+	struct xal_bpf_ctx ctx;
+	struct ring_buffer *rb;
+	struct xal_bpf_events *skel;
+	pthread_t bpf_poll_thread_id;
+	atomic_bool running;
+	atomic_bool should_stop;
+};
+
+int
+xal_be_fiemap_bpf_rb_init(struct xal_bpf *bpf);
+
+int
+xal_be_fiemap_bpf_init(struct xal_bpf *bpf);
+
+void
+xal_be_fiemap_bpf_close(struct xal_bpf *bpf);
+#endif

--- a/include/xal_bpf_events.h
+++ b/include/xal_bpf_events.h
@@ -1,0 +1,40 @@
+#ifndef XAL_BPF_EVENTS_H
+#define XAL_BPF_EVENTS_H
+
+enum xal_event_type {
+	XAL_FS_UNFREEZE_EVENT = 1,
+	// if needed, add more types here
+};
+
+struct xal_bpf_event {
+	uint32_t type;
+
+	uint64_t ts_ns;
+	uint32_t pid;
+	uint32_t tgid;
+	uint32_t cpu;
+
+	uint32_t dev_major;
+	uint32_t dev_minor;
+	uint64_t ino;
+
+	uint32_t fs_block_size;
+
+	uint64_t startoff;
+	uint64_t startblock;
+	uint64_t blockcount;
+	uint32_t state;
+	uint32_t bmap_state;
+};
+
+struct xal_bpf_stat {
+	uint64_t lost_events;
+	uint64_t ignored_events;
+};
+
+struct xal_bpf_ctx {
+	uint32_t dev_major;
+	uint32_t dev_minor;
+	uint32_t fs_block_size;
+};
+#endif

--- a/meson.build
+++ b/meson.build
@@ -55,11 +55,28 @@ vmlinux_h = custom_target(
   capture : true
 )
 
+# BPF: map host cpu_family() to the __TARGET_ARCH_* macro libbpf expects
+bpf_arch_map = {
+  'x86_64'  : 'x86',
+  'x86'     : 'x86',
+  'aarch64' : 'arm64',
+  'arm'     : 'arm',
+  'ppc64'   : 'powerpc',
+  'riscv64' : 'riscv',
+  's390x'   : 's390',
+  'mips64'  : 'mips',
+  'mips'    : 'mips',
+}
+bpf_cpu = host_machine.cpu_family()
+if not bpf_arch_map.has_key(bpf_cpu)
+  error('Unsupported BPF target arch: ' + bpf_cpu)
+endif
+
 # BPF: compile flags
 bpf_cflags = [
   '-O2', '-g',
   '-target', 'bpf',
-  '-D__TARGET_ARCH_x86',
+  '-D__TARGET_ARCH_' + bpf_arch_map[bpf_cpu],
   '-I' + meson.current_build_dir(),
   '-I' + meson.current_source_dir() / 'src',
   '-I' + meson.current_source_dir() / 'include',
@@ -114,7 +131,7 @@ sources = files(
   'src/utils.c'
 )
 
-include_dirs = include_directories('include', 'tp', '.')
+include_dirs = include_directories('include', 'tp')
 
 xal_library = library('xal',
   sources: [skel, sources],

--- a/meson.build
+++ b/meson.build
@@ -36,9 +36,66 @@ xnvme_dep = dependency(
   required: true
 )
 
+# BPF: build dependencies
+libbpf_dep = dependency('libbpf', required: true)
+libelf_dep = dependency('libelf', required: true)
+zlib_dep = dependency('zlib', required: true)
+
+bpftool = find_program('bpftool', required: true)
+clang = find_program('clang', required: true)
+
+# BPF: BTF source file
+vmlinux_btf = '/sys/kernel/btf/vmlinux'
+
+# BPF: generate vmlinux.h
+vmlinux_h = custom_target(
+  'xal-vmlinux-h',
+  output : 'vmlinux.h',
+  command : [bpftool, 'btf', 'dump', 'file', vmlinux_btf, 'format', 'c'],
+  capture : true
+)
+
+# BPF: compile flags
+bpf_cflags = [
+  '-O2', '-g',
+  '-target', 'bpf',
+  '-D__TARGET_ARCH_x86',
+  '-I' + meson.current_build_dir(),
+  '-I' + meson.current_source_dir() / 'src',
+  '-I' + meson.current_source_dir() / 'include',
+]
+
+# BPF: build .bpf.o
+bpf_obj = custom_target(
+  'xal-bpf-events-obj',
+  input : ['src/xal_bpf_events.bpf.c', vmlinux_h],
+  output : 'xal_bpf_events.bpf.o',
+  command : [
+    clang,
+	bpf_cflags,
+	'-c', '@INPUT0@',
+	'-o', '@OUTPUT@'
+  ]
+)
+
+# BPF: generate skeleton
+# 'name' overrides the struct/prefix bpftool would otherwise derive from the
+# object basename ("xal_bpf_events_bpf"). Keep this in sync with the struct
+# name used in src/xal_bpf.c and include/xal_bpf.h.
+skel = custom_target(
+  'xal-bpf-events-skel',
+  input : bpf_obj,
+  output : 'xal_bpf_events.skel.h',
+  command : [bpftool, 'gen', 'skeleton', '@INPUT@', 'name', 'xal_bpf_events'],
+  capture : true
+)
+
 xallib_deps = [
   rt_dep,
   xnvme_dep,
+  libbpf_dep,
+  libelf_dep,
+  zlib_dep,
 ]
 
 public_headers = files(
@@ -50,16 +107,17 @@ sources = files(
   'src/xal.c',
   'src/xal_be_fiemap.c',
   'src/xal_be_fiemap_inotify.c',
+  'src/xal_bpf.c',
   'src/xal_be_xfs.c',
   'src/xal_pool.c',
   'src/pp.c',
   'src/utils.c'
 )
 
-include_dirs = include_directories('include', 'tp')
+include_dirs = include_directories('include', 'tp', '.')
 
 xal_library = library('xal',
-  sources: sources,
+  sources: [skel, sources],
   dependencies: xallib_deps,
   include_directories: include_dirs,
   install: true,

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -16,11 +16,14 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <xal.h>
 #include <xal_be_fiemap.h>
 #include <xal_be_fiemap_inotify.h>
 #include <xal_odf.h>
+#include <xal_bpf_events.h>
+#include <xal_bpf.h>
 
 KHASH_MAP_INIT_STR(path_to_inode, struct xal_inode *)
 
@@ -45,6 +48,10 @@ xal_be_fiemap_close(struct xal *xal)
 	if (be->inotify) {
 		xal_be_fiemap_inotify_close(be->inotify);
 	} else {
+		if (be->bpf) {
+			xal_be_fiemap_bpf_close(be->bpf);
+		}
+
 		int fd = open(be->mountpoint, O_RDONLY | O_DIRECTORY);
 
 		if (fd >= 0) {
@@ -177,6 +184,12 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 	}
 
 	strcpy(be->mountpoint, mountpoint);
+	err = stat(be->mountpoint, &sb);
+	if (err) {
+		XAL_DEBUG("FAILED: stat(%s); errno(%d)", be->mountpoint, errno);
+		err = -errno;
+		goto failed;
+	}
 
 	if (opts->watch_mode) {
 		be->inotify = calloc(1, sizeof(struct xal_inotify));
@@ -193,6 +206,30 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 		}
 	} else {
 		// since fs is mounted without a watch mode, freeze it
+		// + init bpf thread to listen to unfreeze events
+		struct xal_bpf *bpf = calloc(1, sizeof(struct xal_bpf));
+		if (!bpf) {
+			XAL_DEBUG("FAILED: calloc(); errno(%d)", errno);
+			err = -errno;
+			goto failed;
+		}
+
+		// glibc major()/minor() and the kernel's MKDEV(20,12) split on s_dev
+		// produce the same numeric values, so userspace and BPF can compare
+		// directly. If a kernel changes that split, the BPF filter will start
+		// dropping every event as "ignored" -- check skel->bss->stats.ignored_events.
+		bpf->ctx.dev_major = major(sb.st_dev);
+		bpf->ctx.dev_minor = minor(sb.st_dev);
+		bpf->ctx.fs_block_size = sb.st_blksize;
+
+		err = xal_be_fiemap_bpf_init(bpf);
+		if (err) {
+			XAL_DEBUG("FAILED: xal_be_fiemap_bpf_init()");
+			goto failed;
+		}
+
+		be->bpf = bpf;
+
 		int fd = open(mountpoint, O_RDONLY | O_DIRECTORY);
 
 		if (fd < 0) {
@@ -213,19 +250,24 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 			XAL_DEBUG("INFO: froze filesystem");
 		}
 		close(fd);
+
+		err = xal_be_fiemap_bpf_rb_init(be->bpf);
+		if (err) {
+			XAL_DEBUG("FAILED: xal_be_fiemap_bpf_rb_init(); err(%d)", err);
+			goto failed;
+		}
+
+		err = xal_bpf_start_poll_thread(cand);
+		if (err) {
+			XAL_DEBUG("FAILED: xal_bpf_start_poll_thread(); err(%d)", err);
+			goto failed;
+		}
 	}
 
 	nallocated = retrieve_total_entries(be->mountpoint);
 	if (nallocated < 0) {
 		XAL_DEBUG("Failed: retrieve_total_entries()");
 		err = nallocated;
-		goto failed;
-	}
-
-	err = stat(be->mountpoint, &sb);
-	if (err) {
-		XAL_DEBUG("FAILED: stat(%s); errno(%d)", be->mountpoint, errno);
-		err = -errno;
 		goto failed;
 	}
 
@@ -239,6 +281,7 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 	}
 
 	shm = NULL;
+
 	if (opts->shm_name) {
 		snprintf(shm_name, sizeof(shm_name), "%s_inodes", opts->shm_name);
 		shm = shm_name;

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -48,8 +48,11 @@ xal_be_fiemap_close(struct xal *xal)
 		int fd = open(be->mountpoint, O_RDONLY | O_DIRECTORY);
 
 		if (fd >= 0) {
-			if(ioctl(fd, FITHAW, 0) < 0) {
-				XAL_DEBUG("INFO: could not thaw filesystem; maybe nothing to thaw?");
+			int err = ioctl(fd, FITHAW, 0);
+			if (errno == EINVAL) {
+				XAL_DEBUG("INFO: FITHAW returned EINVAL; already thawed?");
+			} else if (err < 0) {
+				XAL_DEBUG("ERROR: could not thaw filesystem; errno(%d)", errno);
 			} else {
 				XAL_DEBUG("INFO: thawed filesystem");
 			}
@@ -200,13 +203,16 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 
 		// when ioctl returns, fs is fully frozen
 		err = ioctl(fd, FIFREEZE, 0);
-		if (err < 0) {
+		if (errno == EBUSY) {
+			XAL_DEBUG("INFO: FIFREEZE returned EBUSY; already frozen?");
+		} else if (err < 0) {
 			close(fd);
-			XAL_DEBUG("FAILED: could not freeze filesystem; err(%d)", err);
+			XAL_DEBUG("FAILED: could not freeze filesystem; errno(%d)", errno);
 			goto failed;
+		} else {
+			XAL_DEBUG("INFO: froze filesystem");
 		}
 		close(fd);
-		XAL_DEBUG("INFO: freezed filesystem");
 	}
 
 	nallocated = retrieve_total_entries(be->mountpoint);

--- a/src/xal_bpf.c
+++ b/src/xal_bpf.c
@@ -1,0 +1,287 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <khash.h>
+#include <libxal.h>
+#include <linux/fs.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+
+#include <xal.h>
+#include <xal_be_fiemap.h>
+#include <xal_odf.h>
+#include <xal_bpf_events.h>
+#include <xal_bpf.h>
+#include <xal_bpf_events.skel.h>
+
+static int
+handle_event(void *__ctx, void *__data, size_t len)
+{
+	const struct xal_bpf_event *e = __data;
+	(void)__ctx;
+
+	if (len < sizeof(*e)) {
+		XAL_DEBUG("FAILED: size of event too small; len(%lu) sizeof(e)(%lu)", len, sizeof(*e));
+		return -EINVAL;
+	}
+
+	switch (e->type) {
+	case XAL_FS_UNFREEZE_EVENT:
+		XAL_DEBUG("WARNING: time(%ld) tgid/pid(%d/%d) cpu(%d) thawed the filesystem dev(%d,%d); unsafe to use extents",
+			e->ts_ns, e->tgid, e->pid, e->cpu, e->dev_major, e->dev_minor);
+		// TODO: set dirty
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+int
+xal_be_fiemap_bpf_rb_init(struct xal_bpf *bpf)
+{
+	struct ring_buffer *rb;
+	int err;
+
+	if (!bpf) {
+		XAL_DEBUG("FAILED: No xal_bpf given");
+		return -EINVAL;
+	}
+
+	// If already exist, free first for clean init
+	if (bpf->rb) {
+		ring_buffer__free(bpf->rb);
+	}
+
+	rb = ring_buffer__new(bpf_map__fd(bpf->skel->maps.events), handle_event, NULL, NULL);
+	if (!rb) {
+		err = -errno;
+		XAL_DEBUG("FAILD: ring_buffer__new(); err(%d)", err);
+		goto out;
+	}
+
+	bpf->rb = rb;
+
+	XAL_DEBUG("INFO: bpf ring buffer initialized");
+	return 0;
+
+out:
+	ring_buffer__free(rb);
+	return err;
+}
+
+int
+xal_be_fiemap_bpf_init(struct xal_bpf *bpf)
+{
+	struct xal_bpf_events *skel = NULL;
+	int err;
+
+	if (!bpf) {
+		XAL_DEBUG("FAILED: No xal_bpf given");
+		return -EINVAL;
+	}
+
+	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+	libbpf_set_print(NULL);
+
+	skel = xal_bpf_events__open();
+	if (!skel) {
+		err = -ENOMEM;
+		XAL_DEBUG("FAILED: xal_bpf_events__open()");
+		goto out;
+	}
+
+	skel->bss->ctx = bpf->ctx;
+
+	err = xal_bpf_events__load(skel);
+	if (err) {
+		XAL_DEBUG("FAILED: xal_bpf_events__load(); err(%d)", err);
+		goto out;
+	}
+
+	err = xal_bpf_events__attach(skel);
+	if (err) {
+		XAL_DEBUG("FAILED: xal_bpf_events__attach(); err(%d)", err);
+		goto out;
+	}
+
+	bpf->skel = skel;
+
+	return 0;
+out:
+	xal_bpf_events__destroy(skel);
+	return err;
+}
+
+void
+xal_be_fiemap_bpf_close(struct xal_bpf *bpf)
+{
+	if (!bpf) {
+		XAL_DEBUG("SKIPPED: No xal_bpf given");
+		return;
+	}
+
+	if (atomic_load(&bpf->running)) {
+		atomic_store(&bpf->should_stop, true);
+		pthread_join(bpf->bpf_poll_thread_id, NULL);
+		XAL_DEBUG("INFO: xal_be_fiemap_bpf_close() joined bpf poll thread");
+	}
+
+	if (bpf->rb) {
+		ring_buffer__free(bpf->rb);
+	}
+
+	if (bpf->skel) {
+		xal_bpf_events__destroy(bpf->skel);
+	}
+
+	free(bpf);
+
+	return;
+}
+
+static int
+read_stats(struct xal_bpf_events *skel, struct xal_bpf_stat *out)
+{
+	*out = skel->bss->stats;
+	return 0;
+}
+
+static void *
+background_bpf_poll(void *arg)
+{
+	struct xal *xal = arg;
+	struct xal_be_fiemap *be = (struct xal_be_fiemap *)xal->be;
+	struct xal_bpf *bpf = be->bpf;
+	struct xal_bpf_stat st;
+	int err = 0;
+
+	XAL_DEBUG("INFO: starting background bpf poll thread");
+
+	while (!atomic_load(&bpf->should_stop)) {
+		err = ring_buffer__poll(bpf->rb, 200);
+		if (err < 0 && err != -EINTR) {
+			XAL_DEBUG("FAILED: ring_buffer__poll(); err(%d)", err);
+			break;
+		}
+
+		err = 0;
+		if (read_stats(bpf->skel, &st) == 0) {
+			// check stats for lost events
+		}
+	}
+
+	pthread_exit((void *)(intptr_t)err);
+}
+
+int
+xal_bpf_start_poll_thread(struct xal *xal)
+{
+	struct xal_backend_base *base;
+	struct xal_be_fiemap *be;
+	struct xal_bpf *bpf;
+	int err;
+
+	if (!xal) {
+		XAL_DEBUG("FAILED: no xal given");
+		return -EINVAL;
+	}
+
+	base = (struct xal_backend_base *)xal->be;
+	if (base->type != XAL_BACKEND_FIEMAP) {
+		XAL_DEBUG("FAILED: Invalid backend type(%d)", base->type);
+		return -ENOTSUP;
+	}
+
+	be = (struct xal_be_fiemap *)base;
+	if (!be->bpf) {
+		XAL_DEBUG("FAILED: xal opened without bpf");
+		return -ENODEV;
+	}
+
+	bpf = be->bpf;
+	if (!bpf->skel) {
+		XAL_DEBUG("FAILED: xal_bpf_events skel not initialized");
+		return -ENOTCONN;
+	}
+
+	if (!bpf->rb) {
+		XAL_DEBUG("FAILED: xal bpf ring buffer not initialized");
+		return -ENOBUFS;
+	}
+
+	if (atomic_load(&bpf->running)) {
+		XAL_DEBUG("SKIPPED: bpf thread already running");
+		return 0;
+	}
+
+	atomic_store(&bpf->should_stop, false);
+	atomic_store(&bpf->running, true);
+
+	err = pthread_create(&bpf->bpf_poll_thread_id, NULL, &background_bpf_poll, xal);
+	if (err) {
+		atomic_store(&bpf->running, false);
+		XAL_DEBUG("FAILED: pthread_create(); err(%d)", err);
+		return -err;
+	}
+
+	return 0;
+}
+
+int
+xal_bpf_stop_poll_thread(struct xal *xal)
+{
+	struct xal_backend_base *base;
+	struct xal_be_fiemap *be;
+	struct xal_bpf *bpf;
+	int err;
+
+	if (!xal) {
+		XAL_DEBUG("FAILED: no xal given");
+		return -EINVAL;
+	}
+
+	base = (struct xal_backend_base *)xal->be;
+	if (base->type != XAL_BACKEND_FIEMAP) {
+		XAL_DEBUG("FAILED: Invalid backend type(%d)", base->type);
+		return -ENOTSUP;
+	}
+
+	be = (struct xal_be_fiemap *)base;
+	if (!be->bpf) {
+		XAL_DEBUG("FAILED: xal opened without bpf");
+		return -ENODEV;
+	}
+
+	bpf = be->bpf;
+	if (!bpf->skel) {
+		XAL_DEBUG("FAILED: xal_bpf_events skel not initialized");
+		return -ENOTCONN;
+	}
+
+	if (!atomic_load(&bpf->running)) {
+		XAL_DEBUG("FAILED: bpf thread is not running");
+		return -ESRCH;
+	}
+
+	atomic_store(&bpf->should_stop, true);
+	err = pthread_join(bpf->bpf_poll_thread_id, NULL);
+	if (err) {
+		XAL_DEBUG("FAILED: pthread_join(); err(%d)", err);
+		return -err;
+	}
+	XAL_DEBUG("INFO: xal_bpf_stop_poll_thread() joined bpf poll thread");
+
+	atomic_store(&bpf->running, false);
+
+	return 0;
+}

--- a/src/xal_bpf_events.bpf.c
+++ b/src/xal_bpf_events.bpf.c
@@ -1,0 +1,89 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include <xal_bpf_events.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 1 << 24);
+} events SEC(".maps");
+
+struct xal_bpf_ctx ctx;
+struct xal_bpf_stat stats;
+
+static __always_inline uint32_t
+dev_major_from_dev(uint32_t dev)
+{
+	return dev >> 20;
+}
+
+static __always_inline uint32_t
+dev_minor_from_dev(uint32_t dev)
+{
+	return dev & ((1U << 20) - 1);
+}
+
+static __always_inline bool
+match_fs(uint32_t dev)
+{
+	if (ctx.dev_major != dev_major_from_dev(dev) ||
+		ctx.dev_minor != dev_minor_from_dev(dev)) {
+		__sync_fetch_and_add(&stats.ignored_events, 1);
+		return false;
+	}
+
+	return true;
+}
+
+static __always_inline void
+fill_event(struct xal_bpf_event *e, enum xal_event_type type, uint64_t ino,
+	   uint64_t startoff, uint64_t startblock, uint64_t blockcount,
+	   uint32_t state, uint32_t bmap_state)
+{
+	uint64_t id = bpf_get_current_pid_tgid();
+
+	e->ts_ns = bpf_ktime_get_ns();
+	e->pid = (uint32_t)id;
+	e->tgid = (uint32_t)(id >> 32);
+	e->cpu = bpf_get_smp_processor_id();
+
+	e->dev_major = ctx.dev_major;
+	e->dev_minor = ctx.dev_minor;
+	e->ino = ino;
+
+	e->type = type;
+	e->fs_block_size = ctx.fs_block_size;
+
+	e->startoff = startoff;
+	e->startblock = startblock;
+	e->blockcount = blockcount;
+	e->state = state;
+	e->bmap_state = bmap_state;
+}
+
+SEC("kprobe/thaw_super")
+int BPF_KPROBE(on_thaw_super, struct super_block *sb)
+{
+	dev_t dev;
+	struct xal_bpf_event *e;
+
+	dev = BPF_CORE_READ(sb, s_dev);
+
+	if (!match_fs(dev)) {
+		return 0;
+	}
+
+	e = bpf_ringbuf_reserve(&events, sizeof(*e), 0);
+	if (!e) {
+		__sync_fetch_and_add(&stats.lost_events, 1);
+		return 0;
+	}
+
+	fill_event(e, XAL_FS_UNFREEZE_EVENT, 0, 0, 0, 0, 0, 0);
+
+	bpf_ringbuf_submit(e, 0);
+	return 0;
+}

--- a/toolbox/pkgs/debian.sh
+++ b/toolbox/pkgs/debian.sh
@@ -16,6 +16,9 @@ apt-get -qy update
 apt-get -qy --no-install-recommends install apt-utils
 apt-get -qy autoclean
 apt-get -qy install \
+ clang \
+ libbpf-dev \
+ llvm \
  meson \
  nbd-client \
  nbdkit \
@@ -26,6 +29,16 @@ apt-get -qy install \
 
 pipx install cijoe==v0.9.51 --force --include-deps
 pipx ensurepath
+
+# Retrieve, build and install bpftool from source. Avoids Ubuntu's linux-tools
+# split, where /usr/sbin/bpftool is a kernel-version-strict wrapper script and
+# the kernel-tools packages don't ship the bpftool binary anyway. xal only
+# uses bpftool to dump BTF from a file, which works with any bpftool version.
+git clone --recurse-submodules https://github.com/libbpf/bpftool.git
+cd bpftool/src
+make
+make install
+cd ../..
 
 # Retrieve, build and install xNVMe from source
 git clone https://github.com/xnvme/xnvme.git


### PR DESCRIPTION
This is a sort of RFC, since it's the first time we tap into kernel space.

A frozen filesystem can be thawed by another process, which would cause xal's cached extents unsafe for use.
This PR implements a bpf program that triggers when this happens, and fills a ring buffer with the event.
User-side polls the ring buffer with a background thread to get the events.

The flow goes like this:
- open xal with `FIEMAP` mode and `watch_mode == 0`
- init bpf structures -> bpf program hooks onto `thaw_super()` through kprobe
- freeze fs
- init bpf ring buffer
- start background poll thread
- `thaw_super()` triggers bpf program -> check the dev major/minor of the call
- if it matches xal's fs, submit the event to the ring buffer
- background poll thread consumes the event and sends a warning message

For now, it only prints a warning message when someone else thaws the fs.
I was thinking we could mark `xal->dirty` and propagate some form of invalidation in the future.
I have also made infrastructure to check lost and ignored events, but I'm not too sure what to do with it yet.
The `struct xal_bpf_event` includes fields such as `startoff`, `blockoff`, etc.
These fields have no use for now, apart from suggesting a generic event structure if we ever want to use bpf for anything else.

Updated README.md and debian.sh files with the additional dependencies.
The `libbpf-dev` package depends on `libelf`, `zlib`, so it should take care of them.
`bpftool` is included in either `linux-tools-common` or `linux-tools-generic`.
Other than that, we need `clang` and `llvm`.
The kernel must be built with `CONFIG_DEBUG_INFO_BTF=y`, which shouldn't be a problem for generic kernels.