### PR TITLE
Fix/bpf mark dirty on thaw

### DIFF
--- a/include/xal_bpf.h
+++ b/include/xal_bpf.h
@@ -14,7 +14,7 @@ struct xal_bpf {
 };
 
 int
-xal_be_fiemap_bpf_rb_init(struct xal_bpf *bpf);
+xal_be_fiemap_bpf_rb_init(struct xal *xal, struct xal_bpf *bpf);
 
 int
 xal_be_fiemap_bpf_init(struct xal_bpf *bpf);

--- a/src/xal_be_fiemap.c
+++ b/src/xal_be_fiemap.c
@@ -251,7 +251,7 @@ xal_be_fiemap_open(struct xal **xal, char *mountpoint, struct xal_opts *opts)
 		}
 		close(fd);
 
-		err = xal_be_fiemap_bpf_rb_init(be->bpf);
+		err = xal_be_fiemap_bpf_rb_init(cand, be->bpf);
 		if (err) {
 			XAL_DEBUG("FAILED: xal_be_fiemap_bpf_rb_init(); err(%d)", err);
 			goto failed;

--- a/src/xal_bpf.c
+++ b/src/xal_bpf.c
@@ -26,7 +26,7 @@ static int
 handle_event(void *__ctx, void *__data, size_t len)
 {
 	const struct xal_bpf_event *e = __data;
-	(void)__ctx;
+	struct xal *xal = __ctx;
 
 	if (len < sizeof(*e)) {
 		XAL_DEBUG("FAILED: size of event too small; len(%lu) sizeof(e)(%lu)", len, sizeof(*e));
@@ -37,7 +37,10 @@ handle_event(void *__ctx, void *__data, size_t len)
 	case XAL_FS_UNFREEZE_EVENT:
 		XAL_DEBUG("WARNING: time(%ld) tgid/pid(%d/%d) cpu(%d) thawed the filesystem dev(%d,%d); unsafe to use extents",
 			e->ts_ns, e->tgid, e->pid, e->cpu, e->dev_major, e->dev_minor);
-		// TODO: set dirty
+		if (xal && xal->dirty) {
+			atomic_store(xal->dirty, true);
+			XAL_DEBUG("WARNING: setting xal->dirty to true");
+		}
 		break;
 	default:
 		break;
@@ -47,7 +50,7 @@ handle_event(void *__ctx, void *__data, size_t len)
 }
 
 int
-xal_be_fiemap_bpf_rb_init(struct xal_bpf *bpf)
+xal_be_fiemap_bpf_rb_init(struct xal *xal, struct xal_bpf *bpf)
 {
 	struct ring_buffer *rb;
 	int err;
@@ -62,7 +65,7 @@ xal_be_fiemap_bpf_rb_init(struct xal_bpf *bpf)
 		ring_buffer__free(bpf->rb);
 	}
 
-	rb = ring_buffer__new(bpf_map__fd(bpf->skel->maps.events), handle_event, NULL, NULL);
+	rb = ring_buffer__new(bpf_map__fd(bpf->skel->maps.events), handle_event, xal, NULL);
 	if (!rb) {
 		err = -errno;
 		XAL_DEBUG("FAILD: ring_buffer__new(); err(%d)", err);

--- a/src/xal_bpf.c
+++ b/src/xal_bpf.c
@@ -68,7 +68,7 @@ xal_be_fiemap_bpf_rb_init(struct xal *xal, struct xal_bpf *bpf)
 	rb = ring_buffer__new(bpf_map__fd(bpf->skel->maps.events), handle_event, xal, NULL);
 	if (!rb) {
 		err = -errno;
-		XAL_DEBUG("FAILD: ring_buffer__new(); err(%d)", err);
+		XAL_DEBUG("FAILED: ring_buffer__new(); err(%d)", err);
 		goto out;
 	}
 
@@ -152,20 +152,13 @@ xal_be_fiemap_bpf_close(struct xal_bpf *bpf)
 	return;
 }
 
-static int
-read_stats(struct xal_bpf_events *skel, struct xal_bpf_stat *out)
-{
-	*out = skel->bss->stats;
-	return 0;
-}
-
 static void *
 background_bpf_poll(void *arg)
 {
 	struct xal *xal = arg;
 	struct xal_be_fiemap *be = (struct xal_be_fiemap *)xal->be;
 	struct xal_bpf *bpf = be->bpf;
-	struct xal_bpf_stat st;
+	uint64_t last_lost_events = 0;
 	int err = 0;
 
 	XAL_DEBUG("INFO: starting background bpf poll thread");
@@ -178,8 +171,14 @@ background_bpf_poll(void *arg)
 		}
 
 		err = 0;
-		if (read_stats(bpf->skel, &st) == 0) {
-			// check stats for lost events
+		uint64_t current_lost = __atomic_load_n(&bpf->skel->bss->stats.lost_events, __ATOMIC_RELAXED);
+		if (current_lost > last_lost_events) {
+			XAL_DEBUG("WARNING: missed %lu BPF events! Marking cache as dirty for safety.",
+				  current_lost - last_lost_events);
+			if (xal && xal->dirty) {
+				atomic_store(xal->dirty, true);
+			}
+			last_lost_events = current_lost;
 		}
 	}
 


### PR DESCRIPTION
2 commits so that we actually do something with the BPF messages triggered by thaw.

**fix(be/fiemap): mark xal dirty on unfreeze event**
Pass the xal struct as context to the BPF ring buffer event handler
so that the unfreeze event can correctly mark the cached xal as
dirty.

**fix(be/fiemap): track lost BPF events and mark cache dirty**
Since missing a BPF event means we might have missed an unfreeze event,
it is no longer safe to assume the cache matches the on-disk state.
This tracks the lost_events counter and marks the cache dirty if any
events are dropped by the ring buffer.
Also, read_stats() was an unnecessary wrapper. Reading directly from
skel->bss->stats is cleaner and avoids allocating the intermediate
struct xal_bpf_stat.