### PR TITLE
fix(xfs): decode shortform dir inodes by directory-wide i8count

### DIFF
--- a/src/xal_be_xfs.c
+++ b/src/xal_be_xfs.c
@@ -1313,8 +1313,11 @@ process_dinode_dir_local(struct xal *xal, struct xal_odf_dinode *dinode, struct 
 		dentry->ftype = *cursor;
 		cursor += 1; ///< Advance past 'ftype'
 
+		/**
+		 * A non-zero 'i8count' means every inode number in the directory --
+		 * including the parent above -- is 64-bit; otherwise all are 32-bit.
+		 */
 		if (i8count) {
-			i8count--;
 			dentry->ino = be64toh(*(uint64_t *)cursor);
 			cursor += 8; ///< Advance past 64-bit inode number
 		} else {


### PR DESCRIPTION
Directories on large multi-AG filesystems reference inodes above the 32-bit boundary, which sets i8count and stores every shortform entry's inode number as 64-bit. Decoding them as 32-bit desynced the cursor and produced bogus inode numbers, so indexing such filesystems failed outright. Honor the per-directory i8count so these directories index correctly on large devices.

This has resolved a longstanding issue where xal would fail to properly parse the filesystem on very large drives.
It has been verified on a 32TB drive.